### PR TITLE
Add explainer dropdown navigation and simplify docs menu

### DIFF
--- a/docs/assets/javascripts/xwhy-nav.js
+++ b/docs/assets/javascripts/xwhy-nav.js
@@ -1,0 +1,190 @@
+(function () {
+  const explainerLinks = [
+    ["All explainers", "explainers/"],
+    ["Image Classification", "explainers/image/"],
+    ["Image Generation", "explainers/image-generation/"],
+    ["Image Editing", "explainers/image-generation/image-editing/"],
+    ["Pix2Pix Models", "explainers/image-generation/pix2pix-models/"],
+    ["LLM", "explainers/llm/"],
+    ["Tabular", "explainers/tabular/"],
+    ["Text", "explainers/text/"],
+    ["Point Cloud", "explainers/point-cloud/"],
+    ["Time Series", "explainers/time-series/"],
+    ["Multimodal", "explainers/multimodal/"]
+  ];
+
+  const tutorialLinks = [
+    ["All tutorials & examples", "tutorials-and-examples/"],
+    ["Image Classification Tutorial", "image_classification_explainer/"],
+    ["LLM Tutorial", "llm_explainer/"],
+    ["LLM Worked Example", "examples/llm-explainer/"],
+    ["Image Examples", "examples/image/"],
+    ["Tabular Examples", "examples/tabular/"],
+    ["Text Examples", "examples/text/"],
+    ["Point-Cloud Examples", "examples/point-cloud/"]
+  ];
+
+  const navLinks = [
+    ["Home", ""],
+    ["Get Started", "getting-started/"],
+    ["Explainers", "explainers/", explainerLinks],
+    ["Tutorials & Examples", "tutorials-and-examples/", tutorialLinks],
+    ["How-to Guides", "how-to/"],
+    ["Evaluation", "evaluation/"],
+    ["API Reference", "reference/"],
+    ["Research", "research/"],
+    ["Contributors", "contributors/"]
+  ];
+
+  function siteRoot() {
+    const marker = "/xwhy/";
+    const path = window.location.pathname;
+    const markerIndex = path.indexOf(marker);
+
+    if (markerIndex >= 0) {
+      return path.slice(0, markerIndex) + marker;
+    }
+
+    return "/";
+  }
+
+  function sitePath(relativePath) {
+    return siteRoot() + relativePath.replace(/^\/+/, "");
+  }
+
+  function normalisePath(path) {
+    if (!path.endsWith("/")) {
+      return path + "/";
+    }
+    return path;
+  }
+
+  function currentPath() {
+    return normalisePath(window.location.pathname);
+  }
+
+  function isExact(href) {
+    return currentPath() === normalisePath(href);
+  }
+
+  function isActive(href) {
+    const path = currentPath();
+    const target = normalisePath(href);
+
+    if (target === normalisePath(siteRoot())) {
+      return path === target;
+    }
+
+    return path === target || path.startsWith(target);
+  }
+
+  function createLink(label, relativePath, className) {
+    const anchor = document.createElement("a");
+    const href = sitePath(relativePath);
+
+    anchor.className = className;
+    anchor.href = href;
+    anchor.textContent = label;
+
+    if (isActive(href)) {
+      anchor.classList.add(className + "--active");
+    }
+
+    if (isExact(href)) {
+      anchor.setAttribute("aria-current", "page");
+    }
+
+    return anchor;
+  }
+
+  function updateActiveState(nav) {
+    nav.querySelectorAll("a[href]").forEach(function (anchor) {
+      const href = new URL(anchor.href).pathname;
+      const active = isActive(href);
+      const exact = isExact(href);
+
+      if (anchor.classList.contains("xwhy-topnav__link")) {
+        anchor.classList.toggle("xwhy-topnav__link--active", active);
+      }
+
+      if (anchor.classList.contains("xwhy-topnav__dropdown-link")) {
+        anchor.classList.toggle("xwhy-topnav__dropdown-link--active", active);
+      }
+
+      if (exact) {
+        anchor.setAttribute("aria-current", "page");
+      } else {
+        anchor.removeAttribute("aria-current");
+      }
+    });
+  }
+
+  function mountTopNav() {
+    const existing = document.querySelector("[data-xwhy-topnav]");
+    if (existing) {
+      updateActiveState(existing);
+      return;
+    }
+
+    const header = document.querySelector(".md-header");
+    if (!header || !header.parentElement) {
+      return;
+    }
+
+    const nav = document.createElement("nav");
+    nav.className = "xwhy-topnav";
+    nav.setAttribute("data-xwhy-topnav", "true");
+    nav.setAttribute("aria-label", "Primary navigation");
+
+    const inner = document.createElement("div");
+    inner.className = "xwhy-topnav__inner";
+
+    const list = document.createElement("ul");
+    list.className = "xwhy-topnav__list";
+
+    navLinks.forEach(function (item) {
+      const label = item[0];
+      const relativePath = item[1];
+      const children = item[2];
+      const listItem = document.createElement("li");
+      listItem.className = "xwhy-topnav__item";
+
+      const link = createLink(label, relativePath, "xwhy-topnav__link");
+      listItem.appendChild(link);
+
+      if (children) {
+        listItem.classList.add("xwhy-topnav__item--has-menu");
+        link.classList.add("xwhy-topnav__link--menu");
+        link.setAttribute("aria-haspopup", "true");
+
+        const submenu = document.createElement("ul");
+        submenu.className = "xwhy-topnav__dropdown";
+        submenu.setAttribute("aria-label", label + " pages");
+
+        children.forEach(function (child) {
+          const childItem = document.createElement("li");
+          childItem.className = "xwhy-topnav__dropdown-item";
+          childItem.appendChild(
+            createLink(child[0], child[1], "xwhy-topnav__dropdown-link")
+          );
+          submenu.appendChild(childItem);
+        });
+
+        listItem.appendChild(submenu);
+      }
+
+      list.appendChild(listItem);
+    });
+
+    inner.appendChild(list);
+    nav.appendChild(inner);
+    updateActiveState(nav);
+    header.insertAdjacentElement("afterend", nav);
+  }
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(mountTopNav);
+  }
+
+  document.addEventListener("DOMContentLoaded", mountTopNav);
+})();

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -69,6 +69,126 @@
   text-align: left;
 }
 
+.xwhy-topnav {
+  background: color-mix(
+    in srgb,
+    var(--md-default-bg-color) 96%,
+    var(--md-accent-fg-color)
+  );
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  box-shadow: 0 0.25rem 0.85rem rgba(15, 23, 42, 0.06);
+  position: sticky;
+  top: 2.4rem;
+  z-index: 3;
+}
+
+.xwhy-topnav__inner {
+  margin: 0 auto;
+  max-width: 90rem;
+  padding: 0.3rem 1.2rem;
+}
+
+.xwhy-topnav__list,
+.xwhy-topnav__dropdown {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.xwhy-topnav__list {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.12rem;
+  justify-content: center;
+}
+
+.xwhy-topnav__item {
+  position: relative;
+}
+
+.xwhy-topnav__link,
+.xwhy-topnav__dropdown-link {
+  align-items: center;
+  border-radius: 0.34rem;
+  color: var(--md-default-fg-color);
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 720;
+  line-height: 1.25;
+  min-height: 1.7rem;
+  padding: 0.4rem 0.48rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.xwhy-topnav__link:hover,
+.xwhy-topnav__link:focus,
+.xwhy-topnav__dropdown-link:hover,
+.xwhy-topnav__dropdown-link:focus {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 10%, transparent);
+  color: var(--md-accent-fg-color);
+  outline: none;
+}
+
+.xwhy-topnav__link--active,
+.xwhy-topnav__dropdown-link--active {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 14%, transparent);
+  color: var(--md-accent-fg-color);
+}
+
+.xwhy-topnav__link--menu::after {
+  border-bottom: 0.21rem solid transparent;
+  border-left: 0.21rem solid transparent;
+  border-right: 0.21rem solid transparent;
+  border-top: 0.25rem solid currentcolor;
+  content: "";
+  margin-left: 0.34rem;
+  transform: translateY(0.08rem);
+}
+
+.xwhy-topnav__dropdown {
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.45rem;
+  box-shadow: 0 0.6rem 1.5rem rgba(15, 23, 42, 0.14);
+  left: 0;
+  max-height: min(70vh, 32rem);
+  min-width: 18rem;
+  opacity: 0;
+  overflow-y: auto;
+  padding: 0.36rem;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  transform: translateY(-0.25rem);
+  transition: opacity 150ms ease, transform 150ms ease, visibility 150ms ease;
+  visibility: hidden;
+  z-index: 5;
+}
+
+.xwhy-topnav__item--has-menu:hover > .xwhy-topnav__dropdown,
+.xwhy-topnav__item--has-menu:focus-within > .xwhy-topnav__dropdown {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  visibility: visible;
+}
+
+.xwhy-topnav__dropdown-link {
+  display: flex;
+  font-size: 0.7rem;
+  justify-content: flex-start;
+  padding: 0.44rem 0.52rem;
+  white-space: normal;
+}
+
+@media screen and (max-width: 76.24em) {
+  .xwhy-topnav {
+    display: none;
+  }
+}
+
 .xwhy-ask-ai {
   bottom: 1.25rem;
   position: fixed;

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,44 @@
+---
+title: XWhy Contributors
+description: Meet the XWhy authors and maintainers, view the current GitHub contributor graph, and learn how to contribute code, documentation, examples, and research artefacts.
+---
+
+# Contributors
+
+XWhy is developed by researchers and software contributors working on explainable, dependable, and responsible artificial intelligence.
+
+[![XWhy GitHub contributors](https://contrib.rocks/image?repo=Dependable-Intelligent-Systems-Lab/xwhy)](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/graphs/contributors)
+
+The contributor image links to the current GitHub contributor graph and updates as new contributions are merged.
+
+## Authors and maintainers
+
+The package metadata currently identifies the following authors and maintainers:
+
+| Contributor | Role recorded in the package metadata |
+| --- | --- |
+| Mojgan Hashemian | Author |
+| Koorosh Aslansefat | Author and maintainer |
+| Hamed Daneshvar | Author and maintainer |
+| Sara Dehghani | Author |
+| Mohammad Naveed Akram | Author |
+| Ioannis Sorokos | Author |
+| Martin Walker | Author |
+| Yiannis Papadopoulos | Author |
+
+## Ways to contribute
+
+Contributions can include:
+
+- explainer implementations and tests;
+- documentation corrections and new tutorials;
+- reproducible worked examples;
+- evaluation metrics and benchmark artefacts;
+- provider and model integrations;
+- accessibility, security, and responsible-use improvements.
+
+Read the [contribution guide](contribute/contributing.md) before opening a pull request.
+
+## Recognition
+
+Authorship, maintainership, software contribution, and publication authorship are distinct forms of contribution. New contributors should be recognised through the repository history and contributor graph. Changes to package authorship or formal research authorship should follow the project's agreed contribution and publication policies.

--- a/docs/tutorials-and-examples/index.md
+++ b/docs/tutorials-and-examples/index.md
@@ -1,0 +1,25 @@
+---
+title: XWhy Tutorials and Examples
+description: Find available and planned XWhy tutorials and worked examples for image classification, LLMs, image generation, tabular data, text, and point clouds.
+---
+
+# Tutorials and examples
+
+Use this directory to select a complete learning path or a focused worked example. Tutorials explain a workflow step by step. Examples show a concrete configuration, representative output, and interpretation.
+
+| Resource | Modality | Type | Status | Coverage |
+| --- | --- | --- | --- | --- |
+| [Image Classification Explainer](../image_classification_explainer.md) | Image | Tutorial | **Available** | Built-in and custom PyTorch classifiers, segmentation, distances, and image plots. |
+| [LLM Explainer](../llm_explainer.md) | LLM | Tutorial | **Available** | Provider setup, prompt perturbation, embeddings, surrogate selection, and token plots. |
+| [LLM Worked Example](../examples/llm-explainer.md) | LLM | Worked example | **Available** | Embedding comparison, real outputs, metrics, and interpretation. |
+| [Image Examples](../examples/image.md) | Image | Example collection | **Coming soon** | Reproducible image-classification examples with stored outputs. |
+| [Image Editing and Pix2Pix Models](../explainers/image-generation/pix2pix-models.md) | Image generation | Planned example | **Under construction** | Conditional image-to-image explanation and Pix2Pix-style model analysis. |
+| [Tabular Examples](../examples/tabular.md) | Tabular | Example collection | **Under construction** | Classification, regression, mixed features, and stability comparisons. |
+| [Text Examples](../examples/text.md) | Text | Example collection | **Under construction** | Token- and phrase-level explanations for conventional text models. |
+| [Point-Cloud Examples](../examples/point-cloud.md) | Point cloud | Example collection | **Under construction** | Point grouping, perturbation comparison, and 3D attribution. |
+
+## Recommended starting points
+
+- New users should begin with the [installation guide](../getting-started/installation.md) and then choose one of the available tutorials.
+- Users comparing capabilities should first review the [explainer directory](../explainers/index.md).
+- Contributors preparing a new example should include executable code, environment details, representative output, quality metrics, and a limitations section.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -10,7 +10,6 @@ copyright: Copyright &copy; XWhy contributors
 theme:
   name: material
   features:
-    - navigation.tabs
     - navigation.sections
     - navigation.indexes
     - navigation.top
@@ -65,6 +64,15 @@ plugins:
           - explainers/point-cloud.md: Point-cloud explainer development status
           - explainers/time-series.md: Planned time-series explainability
           - explainers/multimodal.md: Planned multimodal explainability
+        Tutorials and Examples:
+          - tutorials-and-examples/index.md: Directory of available and planned tutorials and examples
+          - image_classification_explainer.md: Image-classification tutorial
+          - llm_explainer.md: LLM explainer tutorial
+          - examples/llm-explainer.md: Worked LLM example
+          - examples/image.md: Planned image examples
+          - examples/tabular.md: Planned tabular examples
+          - examples/text.md: Planned text examples
+          - examples/point-cloud.md: Planned point-cloud examples
         Concepts:
           - concepts/smile.md: How the SMILE explanation workflow operates
           - concepts/local-explanations.md: Scope of local explanations
@@ -74,6 +82,9 @@ plugins:
         Research:
           - research/index.md: Research and reproducibility entry point
           - research/citation.md: How to cite XWhy
+        Contributors:
+          - contributors.md: Contributors, maintainers, and contribution routes
+          - contribute/contributing.md: Contribution guide
         API Reference:
           - reference/: Generated Python API reference
 
@@ -81,6 +92,7 @@ extra_css:
   - assets/stylesheets/extra.css
 
 extra_javascript:
+  - assets/javascripts/xwhy-nav.js
   - assets/javascripts/ai-links.js
 
 extra:
@@ -110,33 +122,35 @@ nav:
       - Point Cloud: explainers/point-cloud.md
       - Time Series: explainers/time-series.md
       - Multimodal: explainers/multimodal.md
-  - Tutorials:
-      - Image Classification Explainer: image_classification_explainer.md
-      - LLM Explainer: llm_explainer.md
-  - Examples:
-      - Overview: examples/index.md
-      - LLM Explainer: examples/llm-explainer.md
-      - Image: examples/image.md
-      - Tabular: examples/tabular.md
-      - Text: examples/text.md
-      - Point Cloud: examples/point-cloud.md
+  - Tutorials & Examples:
+      - Overview: tutorials-and-examples/index.md
+      - Image Classification Tutorial: image_classification_explainer.md
+      - LLM Tutorial: llm_explainer.md
+      - LLM Worked Example: examples/llm-explainer.md
+      - Image Examples: examples/image.md
+      - Tabular Examples: examples/tabular.md
+      - Text Examples: examples/text.md
+      - Point-Cloud Examples: examples/point-cloud.md
   - How-to Guides:
       - Overview: how-to/index.md
       - Configure Logging: how-to/logging.md
       - Connect Custom Models: how-to/custom-models.md
       - Configure LLM Providers: how-to/providers.md
       - Reproducible Explanations: how-to/reproducibility.md
-  - Concepts:
-      - Overview: concepts/index.md
-      - How SMILE Works: concepts/smile.md
-      - Local Explanations: concepts/local-explanations.md
-      - Limitations and Responsible Use: concepts/limitations.md
   - Evaluation: evaluation/index.md
   - API Reference: reference/
   - Research:
       - Overview: research/index.md
       - Publications: research/publications.md
       - Citation: research/citation.md
-  - Project:
-      - Contributing: contribute/contributing.md
-      - Releasing: RELEASING.md
+  - Contributors:
+      - Overview: contributors.md
+      - Contributing Guide: contribute/contributing.md
+
+not_in_nav: |
+  concepts/index.md
+  concepts/smile.md
+  concepts/local-explanations.md
+  concepts/limitations.md
+  examples/index.md
+  RELEASING.md


### PR DESCRIPTION
## Summary

This update adapts the directory-and-hover-menu pattern used on the `koo-ec.github.io` site for the XWhy documentation.

## Navigation changes

- adds a desktop hover dropdown for **Explainers** while keeping the **Explainers** label clickable;
- keeps `/explainers/` as a table-based directory of all available, under-construction, and planned explainers;
- adds a hover dropdown for **Tutorials & Examples** and a combined table-based landing page;
- merges the previous Tutorials and Examples menu sections into one section;
- removes Concepts from the visible menu while retaining the concept pages for internal links, search, and `llms.txt`;
- removes the Project menu section;
- adds **Contributors** as the final menu section with a contributor page and contribution guide;
- preserves the normal Material for MkDocs mobile navigation and displays the custom hover menu only on desktop-sized screens.

## New pages and assets

- `docs/tutorials-and-examples/index.md`
- `docs/contributors.md`
- `docs/assets/javascripts/xwhy-nav.js`

## Main menu

`Home → Get Started → Explainers → Tutorials & Examples → How-to Guides → Evaluation → API Reference → Research → Contributors`

## Implementation note

The navigation script derives the `/xwhy/` deployment root from the current URL, so links remain correct on GitHub Pages while falling back to `/` for local documentation builds.