### PR TITLE
Separate documentation deployment from full CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,34 +38,3 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  deploy-docs:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.0
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Install Dependencies
-        run: uv sync --group dev
-
-      - name: Configure Git User
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy Documentation
-        run: uv run properdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "properdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "properdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: documentation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install Dependencies
+        run: uv sync --group dev
+
+      - name: Build Documentation
+        run: uv run properdocs build --clean --site-dir site
+
+      - name: Configure Git User
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy Documentation
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: uv run properdocs gh-deploy --force


### PR DESCRIPTION
## Summary

This change makes documentation publication independent from the full package test matrix.

## Changes

- keeps linting, type checks, tests, and coverage in `.github/workflows/ci.yml`;
- moves GitHub Pages publication into `.github/workflows/docs.yml`;
- validates documentation on relevant pull requests;
- deploys documentation on relevant pushes to `main`;
- uses path filters so unrelated source changes do not trigger unnecessary documentation deployments;
- keeps `properdocs gh-deploy --force` and the existing `gh-pages` publishing model.

## Reason

The XWhy source and navigation updates were merged successfully, but the public documentation remained on the previous build because deployment waited behind the complete Nox test suite. This workflow allows documentation changes to be built and published independently while preserving the full CI checks.