### PR TITLE
Fix GitHub Action versions for CI and docs deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Summary

The CI and documentation workflows referenced action versions that do not exist, preventing jobs from starting.

## Fixes

- changes `actions/checkout@v7` to `actions/checkout@v6`;
- changes `astral-sh/setup-uv@v8.3.0` to `astral-sh/setup-uv@v8.1.0`;
- applies the corrections to both `.github/workflows/ci.yml` and `.github/workflows/docs.yml`.

This should allow the independent documentation workflow to build and publish the newly merged navigation to the `gh-pages` branch.