### PR TITLE
Speed up documentation navigation

### DIFF
--- a/docs/assets/javascripts/ai-links.js
+++ b/docs/assets/javascripts/ai-links.js
@@ -163,6 +163,10 @@
     injectAskAiButton();
   }
 
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(init);
+  }
+
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);
   } else {

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -10,6 +10,9 @@ copyright: Copyright &copy; XWhy contributors
 theme:
   name: material
   features:
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
     - navigation.sections
     - navigation.indexes
     - navigation.top
@@ -146,6 +149,9 @@ nav:
   - Contributors:
       - Overview: contributors.md
       - Contributing Guide: contribute/contributing.md
+
+exclude_docs: |
+  gen_ref_pages.py
 
 not_in_nav: |
   concepts/index.md


### PR DESCRIPTION
## Diagnosis

The custom hover menu is not the main cause of the delay. The documentation currently performs a complete browser page load for every internal menu click because Material for MkDocs instant navigation is disabled.

Each full reload restarts:

- the Material search worker and the large generated API-reference search index;
- Google Analytics and external font loading;
- the custom XWhy navigation script;
- the Ask AI and sidebar integrations;
- full HTML, navigation, and sidebar rendering.

## Changes

- enables `navigation.instant` so internal documentation links swap only the page content;
- enables `navigation.instant.prefetch` so a hovered menu destination begins loading before it is clicked;
- enables `navigation.instant.progress` to show feedback only when a request exceeds 400 ms;
- excludes `docs/gen_ref_pages.py` from published documentation and search indexing while continuing to run it through `mkdocs-gen-files`;
- updates `ai-links.js` to re-inject the sidebar panel after an instant-navigation page swap without duplicating the floating Ask AI control.

## Expected effect

The initial site visit still loads the theme and search index once, but movement between menus and documentation pages should no longer reload the full application. The existing search index is retained in memory across page changes, which is particularly important for a documentation site with a large generated API reference.