### PR TITLE
Remove API reference from documentation menu

### DIFF
--- a/docs/assets/javascripts/xwhy-nav.js
+++ b/docs/assets/javascripts/xwhy-nav.js
@@ -31,7 +31,6 @@
     ["Tutorials & Examples", "tutorials-and-examples/", tutorialLinks],
     ["How-to Guides", "how-to/"],
     ["Evaluation", "evaluation/"],
-    ["API Reference", "reference/"],
     ["Research", "research/"],
     ["Contributors", "contributors/"]
   ];

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -141,7 +141,6 @@ nav:
       - Configure LLM Providers: how-to/providers.md
       - Reproducible Explanations: how-to/reproducibility.md
   - Evaluation: evaluation/index.md
-  - API Reference: reference/
   - Research:
       - Overview: research/index.md
       - Publications: research/publications.md
@@ -159,4 +158,5 @@ not_in_nav: |
   concepts/local-explanations.md
   concepts/limitations.md
   examples/index.md
+  reference/
   RELEASING.md


### PR DESCRIPTION
Removes **API Reference** from both visible navigation systems:

- the standard Material for MkDocs navigation in `properdocs.yml`;
- the custom desktop top navigation in `xwhy-nav.js`.

The generated API reference remains available through direct URLs, internal links, documentation search, and `llms.txt`; it is only removed from the visible menu.