### PR TITLE
Populate SMILE research publications and citation guidance

### DIFF
--- a/docs/assets/javascripts/xwhy-nav.js
+++ b/docs/assets/javascripts/xwhy-nav.js
@@ -24,6 +24,12 @@
     ["Point-Cloud Examples", "examples/point-cloud/"]
   ];
 
+  const researchLinks = [
+    ["Research overview", "research/"],
+    ["Publications", "research/publications/"],
+    ["Citation guidance", "research/citation/"]
+  ];
+
   const navLinks = [
     ["Home", ""],
     ["Get Started", "getting-started/"],
@@ -31,7 +37,7 @@
     ["Tutorials & Examples", "tutorials-and-examples/", tutorialLinks],
     ["How-to Guides", "how-to/"],
     ["Evaluation", "evaluation/"],
-    ["Research", "research/"],
+    ["Research", "research/", researchLinks],
     ["Contributors", "contributors/"]
   ];
 

--- a/docs/research/citation.md
+++ b/docs/research/citation.md
@@ -1,18 +1,108 @@
 ---
-title: Cite XWhy
-description: Current citation guidance for the XWhy software repository and forthcoming formal software and method citations.
+title: Cite XWhy and SMILE
+description: Citation guidance for XWhy software and the SMILE research family, including the foundational method and modality-specific extensions.
 ---
 
-# Cite XWhy
+# Cite XWhy and SMILE
 
-!!! info "Formal citation coming soon"
-    A versioned software citation and verified method bibliography are being prepared.
+Cite the **software artefact** you used and the **research method** that supports your analysis. These are related but distinct citations.
 
-Until a `CITATION.cff` file and archived software release are available, cite the specific XWhy version or commit used and include the repository URL and access date.
+## Citation decision table
 
-A complete citation page should later provide:
+| What you used or discussed | Recommended research citation |
+| --- | --- |
+| General SMILE method, local statistical weighting, or classifier explanations | Foundational SMILE paper |
+| Point-cloud explanations | Foundational SMILE paper + point-cloud SMILE preprint |
+| Instruction-based image-editing explanations | Foundational SMILE paper + image-editing SMILE preprint |
+| Large-language-model prompt explanations | Foundational SMILE paper + gSMILE preprint |
+| Knowledge-graph or GraphRAG explanations | Foundational SMILE paper + KG-SMILE preprint |
+| Concept-based explanation auditing | Foundational SMILE paper + ConceptSMILE preprint |
+| Financial-sentiment reasoning with local perturbation explanations | gSMILE preprint + financial-sentiment study |
+| The consolidated MSc study of generative-AI explainability | MSc thesis; add the relevant method paper where applicable |
 
-- a software citation with version and DOI;
-- BibTeX and plain-text formats;
-- citations for SMILE and modality-specific methods;
-- guidance for citing examples, datasets, and benchmarks.
+## Foundational SMILE citation
+
+Use this as the primary methodological citation when referring to SMILE generally:
+
+> Koorosh Aslansefat, Mojgan Hashemian, Martin Walker, Mohammed Naveed Akram, Ioannis Sorokos, and Yiannis Papadopoulos. “Explaining Black Boxes with a SMILE: Statistical Model-Agnostic Interpretability with Local Explanations.” *IEEE Software*, 41(1), 87–97, 2024. <https://doi.org/10.1109/MS.2023.3321282>
+
+```bibtex
+@article{aslansefat2024smile,
+  author    = {Koorosh Aslansefat and Mojgan Hashemian and Martin Walker
+               and Mohammed Naveed Akram and Ioannis Sorokos
+               and Yiannis Papadopoulos},
+  title     = {Explaining Black Boxes with a {SMILE}: Statistical
+               Model-Agnostic Interpretability with Local Explanations},
+  journal   = {IEEE Software},
+  year      = {2024},
+  volume    = {41},
+  number    = {1},
+  pages     = {87--97},
+  month     = {Jan.--Feb.},
+  publisher = {IEEE},
+  doi       = {10.1109/MS.2023.3321282},
+  url       = {https://doi.org/10.1109/MS.2023.3321282}
+}
+```
+
+## Modality-specific citations
+
+### Point clouds
+
+Cite the foundational SMILE paper and:
+
+> Seyed Mohammad Ahmadi, Koorosh Aslansefat, Rubén Valcarce-Diñeiro, and Joshua Barnfather. “Explainability of Point Cloud Neural Networks Using SMILE: Statistical Model-Agnostic Interpretability with Local Explanations.” arXiv:2410.15374, 2024. <https://arxiv.org/abs/2410.15374>
+
+### Instruction-based image editing
+
+Cite the foundational SMILE paper and:
+
+> Zeinab Dehghani, Koorosh Aslansefat, Adil Khan, Adín Ramírez Rivera, Franky George, and Muhammad Khalid. “Mapping the Mind of an Instruction-Based Image Editing Using SMILE.” arXiv:2412.16277, 2024. <https://arxiv.org/abs/2412.16277>
+
+### Large language models
+
+Cite the foundational SMILE paper and:
+
+> Zeinab Dehghani, Mohammed Naveed Akram, Koorosh Aslansefat, Adil Khan, and Yiannis Papadopoulos. “Explaining Large Language Models with gSMILE.” arXiv:2505.21657, 2025. <https://arxiv.org/abs/2505.21657>
+
+### Knowledge-graph retrieval-augmented generation
+
+Cite the foundational SMILE paper and:
+
+> Zahra Zehtabi Sabeti Moghaddam, Zeinab Dehghani, Maneeha Rani, Koorosh Aslansefat, Bhupesh Kumar Mishra, Rameez Raja Kureshi, and Dhavalkumar Thakker. “Explainable Knowledge Graph Retrieval-Augmented Generation (KG-RAG) with KG-SMILE.” arXiv:2509.03626, 2025. <https://arxiv.org/abs/2509.03626>
+
+### Concept-based explainability
+
+Cite the foundational SMILE paper and:
+
+> Mohadeseh Mollapour, Koorosh Aslansefat, Zeinab Dehghani, Bhupesh Kumar Mishra, Tejal Shah, and Zhibao Mian. “ConceptSMILE: Auditing the Trustworthiness of Concept-Based Explainable AI.” arXiv:2607.09649, 2026. <https://arxiv.org/abs/2607.09649>
+
+### Financial-sentiment reasoning
+
+For the applied financial-sentiment study, cite gSMILE and:
+
+> Sania Verma, Koorosh Aslansefat, Joyjit Chatterjee, Akash Marar, Anu Mehra, and Aisha Ekundayo. “When Words Move Markets: Interpretable Behavioural and Robustness Analysis of LLMs for Financial Sentiment Reasoning via Local Perturbation Explanations.” In *Natural Language Processing and Information Systems: NLDB 2026*, LNCS 16696, 271–286. Springer, 2027; first published online 4 July 2026. <https://doi.org/10.1007/978-3-032-29532-3_19>
+
+The [publication catalogue](publications.md) provides complete BibTeX records for every method and study.
+
+## Citing the XWhy software
+
+A research-method citation does not identify the exact software revision used in an experiment. Until the repository provides a versioned archived software release and formal software DOI, record:
+
+- the package version;
+- the Git commit SHA when reproducibility is important;
+- the repository URL;
+- the date on which the software was accessed;
+- the configuration, model, data, and random seed used.
+
+A temporary plain-text software reference can use this form:
+
+> XWhy contributors. *XWhy: Model-Agnostic Explainability with SMILE*. Version or commit used. GitHub repository: <https://github.com/Dependable-Intelligent-Systems-Lab/xwhy>. Accessed YYYY-MM-DD.
+
+## Citation principles
+
+1. **Cite the foundational method** when the work depends on SMILE’s statistical local-surrogate formulation.
+2. **Add the relevant extension** when the explained system is a point cloud, image editor, LLM, KG-RAG pipeline, or concept-based model.
+3. **Distinguish preprints from peer-reviewed publications** in prose and bibliographies.
+4. **List the thesis separately** from journal and conference papers.
+5. **Record the software revision** independently from the paper citation so an experiment can be reproduced.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,15 +1,52 @@
 ---
-title: XWhy Research and Reproducibility
-description: Research entry point for XWhy, SMILE publications, benchmarks, software citation, and reproducible experiments.
+title: SMILE Research and Publications
+description: Research overview of the SMILE explainability family, including the foundational method and extensions for point clouds, image editing, large language models, knowledge-graph RAG, concepts, and financial sentiment reasoning.
 ---
 
 # Research
 
-This section will connect the software to its scientific foundations and reproducibility artefacts.
+SMILE—**Statistical Model-Agnostic Interpretability with Local Explanations**—is a family of local explainability methods for analysing black-box artificial-intelligence systems. The foundational method explains machine-learning classifiers by fitting a local surrogate model whose perturbed samples are weighted using statistical distance measures. Later work adapts this principle to spatial, generative, language, retrieval-augmented, and concept-based systems.
 
-- [Publications](publications.md)
-- [Citation guidance](citation.md)
-- [Reproducibility guide](../how-to/reproducibility.md)
+## Research map
 
-!!! info "Coming soon"
-    A benchmark catalogue, dataset registry, method-comparison table, and paper-to-code mapping are planned.
+| Research area | Method or study | Explained system | Publication status |
+| --- | --- | --- | --- |
+| Core method | SMILE | Machine-learning and deep-learning classifiers | Peer-reviewed journal article |
+| Vision and spatial AI | Point-cloud SMILE | Point-cloud neural networks | arXiv preprint |
+| Vision and generative AI | Image-editing SMILE | Instruction-based image-editing models | arXiv preprint |
+| Language and generative AI | gSMILE | Large language models | arXiv preprint |
+| Retrieval-augmented generation | KG-SMILE | Knowledge-graph and GraphRAG systems | arXiv preprint |
+| Concept-based explainability | ConceptSMILE | Concept-based explainable-AI methods | arXiv preprint |
+| Financial language analysis | Local perturbation explanations derived from gSMILE | LLM financial-sentiment reasoning | Peer-reviewed conference chapter |
+| Consolidated academic study | Generative-AI SMILE thesis | LLMs and instruction-based image editing | MSc thesis |
+
+## How the research family is organised
+
+### Core method
+
+The foundational SMILE paper defines the statistical-distance-based local explanation framework for black-box classifiers. This is the principal methodological citation for general references to SMILE.
+
+### Vision and spatial AI
+
+The point-cloud extension explains influential groups of 3D points and evaluates explanation fidelity, stability, and robustness. The image-editing extension instead perturbs natural-language editing instructions and measures how words or phrases affect generated visual changes.
+
+### Language and generative AI
+
+gSMILE explains large-language-model behaviour by perturbing prompt components, measuring changes in model outputs with statistical distances such as Wasserstein distance, and fitting a locally weighted surrogate model. A related financial-sentiment study applies local perturbation explanations to behavioural and robustness analysis.
+
+### Retrieval-augmented generation
+
+KG-SMILE explains the contribution of retrieved entities, relations, graph paths, and contextual evidence within knowledge-graph retrieval-augmented generation workflows.
+
+### Concept-based explainability
+
+ConceptSMILE audits whether human-understandable concepts provide explanations that are faithful, locally representative, stable, and consistent.
+
+## Research resources
+
+- [Browse the complete publication catalogue](publications.md)
+- [Choose the correct citation for your use case](citation.md)
+- [Follow the reproducibility guidance](../how-to/reproducibility.md)
+
+!!! note "Publication metadata"
+    The publication types, identifiers, links, and BibTeX records in this section are maintained from the project bibliography. Preprints and online-first records may later receive updated journal, conference, volume, issue, or pagination metadata.

--- a/docs/research/publications.md
+++ b/docs/research/publications.md
@@ -1,19 +1,256 @@
 ---
 title: XWhy and SMILE Publications
-description: Planned verified bibliography connecting XWhy implementations to SMILE, gSMILE, and related explainability research.
+description: Complete publication catalogue for the SMILE explainability family, including DOI and arXiv links, publication status, method scope, and BibTeX records.
 ---
 
 # Publications
 
-!!! info "Coming soon"
-    The verified publication list, DOI links, BibTeX records, implementation mapping, and reproduction notes are being prepared.
+This catalogue connects the SMILE research family to the systems each publication explains. The foundational paper defines the core statistical local-explanation method; later publications extend or apply that principle to point clouds, image editing, large language models, knowledge-graph retrieval, concepts, and financial sentiment reasoning.
 
-Each publication entry should state:
+## Publication catalogue
 
-- the exact method or XWhy component it supports;
-- publication status and persistent identifier;
-- code version or commit used;
-- dataset and model details;
-- available reproduction artefacts.
+| Year | Method or study | Explained system | Type | Persistent identifier |
+| --- | --- | --- | --- | --- |
+| 2024 | Foundational SMILE | ML and deep-learning classifiers | IEEE Software article | [DOI](https://doi.org/10.1109/MS.2023.3321282) |
+| 2024 | Point-cloud SMILE | Point-cloud neural networks | arXiv preprint | [arXiv:2410.15374](https://arxiv.org/abs/2410.15374) |
+| 2024 | Image-editing SMILE | Instruction-based image editing | arXiv preprint | [arXiv:2412.16277](https://arxiv.org/abs/2412.16277) |
+| 2025 | gSMILE | Large language models | arXiv preprint | [arXiv:2505.21657](https://arxiv.org/abs/2505.21657) |
+| 2025 | KG-SMILE | Knowledge-graph and GraphRAG systems | arXiv preprint | [arXiv:2509.03626](https://arxiv.org/abs/2509.03626) |
+| 2026 | ConceptSMILE | Concept-based explainable AI | arXiv preprint | [arXiv:2607.09649](https://arxiv.org/abs/2607.09649) |
+| 2026/2027 | Financial-sentiment local perturbation study | LLM financial-sentiment reasoning | NLDB 2026 conference chapter; 2027 volume | [DOI](https://doi.org/10.1007/978-3-032-29532-3_19) |
+| 2025 | Generative-AI SMILE thesis | LLM and image-editing explainability | MSc thesis | [arXiv:2602.01206](https://arxiv.org/abs/2602.01206) |
 
-Do not add provisional or unverified citation metadata to this page.
+## Core method
+
+### Explaining Black Boxes with a SMILE
+
+**Koorosh Aslansefat, Mojgan Hashemian, Martin Walker, Mohammed Naveed Akram, Ioannis Sorokos, and Yiannis Papadopoulos.** “Explaining Black Boxes with a SMILE: Statistical Model-Agnostic Interpretability with Local Explanations.” *IEEE Software*, 41(1), 87–97, 2024.
+
+The foundational paper introduces model-agnostic local explanations for black-box machine-learning and deep-learning classifiers. SMILE uses statistical distance measures to weight perturbed samples when fitting a local surrogate model, rather than relying only on geometric proximity.
+
+[DOI](https://doi.org/10.1109/MS.2023.3321282) · [IEEE Xplore](https://ieeexplore.ieee.org/document/10269706)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @article{aslansefat2024smile,
+      author    = {Koorosh Aslansefat and Mojgan Hashemian and Martin Walker
+                   and Mohammed Naveed Akram and Ioannis Sorokos
+                   and Yiannis Papadopoulos},
+      title     = {Explaining Black Boxes with a {SMILE}: Statistical
+                   Model-Agnostic Interpretability with Local Explanations},
+      journal   = {IEEE Software},
+      year      = {2024},
+      volume    = {41},
+      number    = {1},
+      pages     = {87--97},
+      month     = {Jan.--Feb.},
+      publisher = {IEEE},
+      doi       = {10.1109/MS.2023.3321282},
+      url       = {https://doi.org/10.1109/MS.2023.3321282}
+    }
+    ```
+
+## Vision and spatial AI
+
+### Explainability of Point Cloud Neural Networks Using SMILE
+
+**Seyed Mohammad Ahmadi, Koorosh Aslansefat, Rubén Valcarce-Diñeiro, and Joshua Barnfather.** “Explainability of Point Cloud Neural Networks Using SMILE: Statistical Model-Agnostic Interpretability with Local Explanations.” arXiv:2410.15374, 2024.
+
+This extension identifies local groups or clusters of 3D points that most strongly influence a point-cloud neural network. Its evaluation considers explanation fidelity, stability, and robustness, with relevance to robotics, LiDAR perception, autonomous systems, and industrial inspection.
+
+[Abstract](https://arxiv.org/abs/2410.15374) · [PDF](https://arxiv.org/pdf/2410.15374)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @misc{ahmadi2024pointcloudsmile,
+      author        = {Seyed Mohammad Ahmadi and Koorosh Aslansefat
+                       and Rub{\'e}n Valcarce-Di{\~n}eiro
+                       and Joshua Barnfather},
+      title         = {Explainability of Point Cloud Neural Networks Using
+                       {SMILE}: Statistical Model-Agnostic Interpretability
+                       with Local Explanations},
+      year          = {2024},
+      eprint        = {2410.15374},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.LG},
+      doi           = {10.48550/arXiv.2410.15374},
+      url           = {https://arxiv.org/abs/2410.15374}
+    }
+    ```
+
+### Mapping the Mind of an Instruction-Based Image Editing Using SMILE
+
+**Zeinab Dehghani, Koorosh Aslansefat, Adil Khan, Adín Ramírez Rivera, Franky George, and Muhammad Khalid.** “Mapping the Mind of an Instruction-Based Image Editing Using SMILE.” arXiv:2412.16277, 2024.
+
+This work applies SMILE to instruction-based generative image-editing systems. It perturbs words or phrases in the editing instruction and measures changes in the generated image, revealing which parts of the instruction drive particular visual modifications.
+
+[Abstract](https://arxiv.org/abs/2412.16277) · [PDF](https://arxiv.org/pdf/2412.16277)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @misc{dehghani2024imageeditingsmile,
+      author        = {Zeinab Dehghani and Koorosh Aslansefat
+                       and Adil Khan and Ad{\'i}n Ram{\'i}rez Rivera
+                       and Franky George and Muhammad Khalid},
+      title         = {Mapping the Mind of an Instruction-Based Image
+                       Editing Using {SMILE}},
+      year          = {2024},
+      eprint        = {2412.16277},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.AI},
+      doi           = {10.48550/arXiv.2412.16277},
+      url           = {https://arxiv.org/abs/2412.16277}
+    }
+    ```
+
+## Language and generative AI
+
+### Explaining Large Language Models with gSMILE
+
+**Zeinab Dehghani, Mohammed Naveed Akram, Koorosh Aslansefat, Adil Khan, and Yiannis Papadopoulos.** “Explaining Large Language Models with gSMILE.” arXiv:2505.21657, 2025.
+
+gSMILE perturbs prompt tokens or textual components, observes changes in model outputs, measures those changes with statistical distances such as Wasserstein distance, and fits a locally weighted surrogate model. The resulting token-level explanations can be used to study prompt influence, response sensitivity, instability, and potentially unsafe dependence on particular prompt elements.
+
+[Abstract](https://arxiv.org/abs/2505.21657) · [PDF](https://arxiv.org/pdf/2505.21657)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @misc{dehghani2025gsmile,
+      author        = {Zeinab Dehghani and Mohammed Naveed Akram
+                       and Koorosh Aslansefat and Adil Khan
+                       and Yiannis Papadopoulos},
+      title         = {Explaining Large Language Models with {gSMILE}},
+      year          = {2025},
+      eprint        = {2505.21657},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.CL},
+      doi           = {10.48550/arXiv.2505.21657},
+      url           = {https://arxiv.org/abs/2505.21657}
+    }
+    ```
+
+### When Words Move Markets
+
+**Sania Verma, Koorosh Aslansefat, Joyjit Chatterjee, Akash Marar, Anu Mehra, and Aisha Ekundayo.** “When Words Move Markets: Interpretable Behavioural and Robustness Analysis of LLMs for Financial Sentiment Reasoning via Local Perturbation Explanations.” In *Natural Language Processing and Information Systems: NLDB 2026*, LNCS 16696, 271–286. Springer, 2027; first published online 4 July 2026.
+
+This study applies local perturbation explanations derived from the gSMILE approach to financial-sentiment reasoning. It investigates which words, phrases, and contextual cues influence an LLM’s financial-sentiment outcome and whether the behaviour and explanation remain stable under rewording or small perturbations.
+
+[DOI](https://doi.org/10.1007/978-3-032-29532-3_19) · [SpringerLink](https://link.springer.com/chapter/10.1007/978-3-032-29532-3_19)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @inproceedings{verma2027wordsmarkets,
+      author    = {Sania Verma and Koorosh Aslansefat and Joyjit Chatterjee
+                   and Akash Marar and Anu Mehra and Aisha Ekundayo},
+      title     = {When Words Move Markets: Interpretable Behavioural and
+                   Robustness Analysis of {LLM}s for Financial Sentiment
+                   Reasoning via Local Perturbation Explanations},
+      booktitle = {Natural Language Processing and Information Systems:
+                   {NLDB} 2026},
+      editor    = {Elena Cabrio and Eric Monteiro},
+      series    = {Lecture Notes in Computer Science},
+      volume    = {16696},
+      pages     = {271--286},
+      year      = {2027},
+      publisher = {Springer},
+      address   = {Cham},
+      doi       = {10.1007/978-3-032-29532-3_19},
+      isbn      = {978-3-032-29532-3},
+      url       = {https://doi.org/10.1007/978-3-032-29532-3_19},
+      note      = {First published online 4 July 2026;
+                   presented at NLDB 2026}
+    }
+    ```
+
+## Retrieval-augmented generation
+
+### Explainable Knowledge Graph Retrieval-Augmented Generation with KG-SMILE
+
+**Zahra Zehtabi Sabeti Moghaddam, Zeinab Dehghani, Maneeha Rani, Koorosh Aslansefat, Bhupesh Kumar Mishra, Rameez Raja Kureshi, and Dhavalkumar Thakker.** “Explainable Knowledge Graph Retrieval-Augmented Generation (KG-RAG) with KG-SMILE.” arXiv:2509.03626, 2025.
+
+KG-SMILE examines the contribution of retrieved entities, relations, graph paths, and contextual evidence to the answer generated by a knowledge-graph retrieval-augmented generation system. It is intended to expose irrelevant retrieval, unsupported reasoning paths, and excessive dependence on individual graph elements.
+
+[Abstract](https://arxiv.org/abs/2509.03626) · [PDF](https://arxiv.org/pdf/2509.03626)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @misc{moghaddam2025kgsmile,
+      author        = {Zahra Zehtabi Sabeti Moghaddam and Zeinab Dehghani
+                       and Maneeha Rani and Koorosh Aslansefat
+                       and Bhupesh Kumar Mishra and Rameez Raja Kureshi
+                       and Dhavalkumar Thakker},
+      title         = {Explainable Knowledge Graph Retrieval-Augmented
+                       Generation ({KG-RAG}) with {KG-SMILE}},
+      year          = {2025},
+      eprint        = {2509.03626},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.AI},
+      doi           = {10.48550/arXiv.2509.03626},
+      url           = {https://arxiv.org/abs/2509.03626}
+    }
+    ```
+
+## Concept-based explainability
+
+### ConceptSMILE
+
+**Mohadeseh Mollapour, Koorosh Aslansefat, Zeinab Dehghani, Bhupesh Kumar Mishra, Tejal Shah, and Zhibao Mian.** “ConceptSMILE: Auditing the Trustworthiness of Concept-Based Explainable AI.” arXiv:2607.09649, 2026.
+
+ConceptSMILE audits whether higher-level, human-understandable concepts provide explanations that are faithful to the model, locally representative, stable under small changes, and consistent across related inputs. This is particularly relevant where explanations must be meaningful to domain experts as well as technically aligned with model behaviour.
+
+[Abstract](https://arxiv.org/abs/2607.09649) · [PDF](https://arxiv.org/pdf/2607.09649)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @misc{mollapour2026conceptsmile,
+      author        = {Mohadeseh Mollapour and Koorosh Aslansefat
+                       and Zeinab Dehghani and Bhupesh Kumar Mishra
+                       and Tejal Shah and Zhibao Mian},
+      title         = {{ConceptSMILE}: Auditing the Trustworthiness of
+                       Concept-Based Explainable {AI}},
+      year          = {2026},
+      eprint        = {2607.09649},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.AI},
+      doi           = {10.48550/arXiv.2607.09649},
+      url           = {https://arxiv.org/abs/2607.09649}
+    }
+    ```
+
+## Related thesis
+
+### Addressing Explainability of Generative AI Using SMILE
+
+**Zeinab Dehghani.** “Addressing Explainability of Generative AI Using SMILE: Statistical Model-Agnostic Interpretability with Local Explanations.” MSc thesis, University of Hull, September 2025. Also available as arXiv:2602.01206.
+
+The thesis consolidates the use of SMILE for generative artificial intelligence, particularly large language models and instruction-based image-editing systems. It is listed separately because it is a thesis rather than a peer-reviewed journal or conference publication.
+
+[Abstract](https://arxiv.org/abs/2602.01206) · [PDF](https://arxiv.org/pdf/2602.01206)
+
+??? note "BibTeX"
+
+    ```bibtex
+    @mastersthesis{dehghani2025generativeaismile,
+      author = {Zeinab Dehghani},
+      title  = {Addressing Explainability of Generative {AI} Using
+                {SMILE}: Statistical Model-Agnostic Interpretability
+                with Local Explanations},
+      school = {University of Hull},
+      type   = {{MSc} thesis},
+      year   = {2025},
+      month  = {September},
+      note   = {Also available as arXiv:2602.01206},
+      doi    = {10.48550/arXiv.2602.01206},
+      url    = {https://arxiv.org/abs/2602.01206}
+    }
+    ```
+
+!!! note "Maintaining citation metadata"
+    Use the DOI for formally published work and the arXiv identifier for current preprints. When a preprint receives a peer-reviewed publication record, retain the arXiv link for version history but update the preferred citation to the final publisher metadata.


### PR DESCRIPTION
## Summary

This change replaces the placeholder Research section with a structured, source-based catalogue of the SMILE explainability research family.

## Content added

- a research map separating the foundational method from modality-specific extensions;
- the complete publication catalogue supplied for the project;
- explicit publication-status labels for journal articles, conference chapters, arXiv preprints, and the MSc thesis;
- DOI, publisher, arXiv abstract, and PDF links;
- expandable BibTeX records for all eight entries;
- citation guidance explaining when to cite the foundational SMILE paper and when to add a modality-specific extension;
- separate guidance for citing the XWhy software revision used in an experiment;
- a Research hover dropdown linking directly to the overview, publications, and citation pages.

## Research grouping

- Core method
- Vision and spatial AI
- Language and generative AI
- Retrieval-augmented generation
- Concept-based explainability
- Related MSc thesis

## Source handling

The publication titles, author lists, identifiers, dates, and BibTeX records are based on the supplied SMILE explainability bibliography. Preprints are not presented as peer-reviewed publications, and the MSc thesis is listed separately from journal and conference papers.