### PR TITLE
Add modality-aware ATT evaluation documentation

### DIFF
--- a/docs/assets/javascripts/xwhy-nav.js
+++ b/docs/assets/javascripts/xwhy-nav.js
@@ -24,6 +24,15 @@
     ["Point-Cloud Examples", "examples/point-cloud/"]
   ];
 
+  const evaluationLinks = [
+    ["Evaluation overview", "evaluation/"],
+    ["ATT Fidelity", "evaluation/attribution-fidelity/"],
+    ["ATT Accuracy", "evaluation/attribution-accuracy/"],
+    ["ATT Stability", "evaluation/attribution-stability/"],
+    ["ATT Consistency", "evaluation/attribution-consistency/"],
+    ["ATT Faithfulness", "evaluation/attribution-faithfulness/"]
+  ];
+
   const researchLinks = [
     ["Research overview", "research/"],
     ["Publications", "research/publications/"],
@@ -36,7 +45,7 @@
     ["Explainers", "explainers/", explainerLinks],
     ["Tutorials & Examples", "tutorials-and-examples/", tutorialLinks],
     ["How-to Guides", "how-to/"],
-    ["Evaluation", "evaluation/"],
+    ["Evaluation", "evaluation/", evaluationLinks],
     ["Research", "research/", researchLinks],
     ["Contributors", "contributors/"]
   ];

--- a/docs/evaluation/attribution-accuracy.md
+++ b/docs/evaluation/attribution-accuracy.md
@@ -1,0 +1,112 @@
+---
+title: ATT Accuracy
+description: Define attribution accuracy as alignment with modality-appropriate reference evidence and document XWhy's image coverage functions.
+---
+
+# ATT accuracy
+
+**ATT accuracy** asks whether the features assigned high importance by an explanation align with suitable reference evidence.
+
+This is **not** the predictive accuracy of the black-box model. It is the accuracy of the attribution relative to a reference that identifies which tokens, regions, points, graph elements, or concepts should be relevant.
+
+## Required inputs
+
+An ATT accuracy evaluation needs:
+
+1. attribution scores for interpretable features;
+2. a reference attribution or relevance annotation;
+3. a rule for matching explanation features to reference features;
+4. an aggregation metric and thresholding policy, where applicable.
+
+The reference may come from human annotation, a semantic mask, domain-expert evidence, a controlled synthetic task, or another defensible source. The quality and uncertainty of that reference must be reported.
+
+## Modality-specific definitions
+
+| Modality | Attribution unit | Reference example | Suitable evaluation examples |
+|---|---|---|---|
+| Image classification | Pixels, superpixels, regions | Object or lesion mask | Coverage, weighted coverage, overlap, ranking against annotated regions |
+| LLM / gSMILE | Tokens, words, phrases | Human-labelled influential text elements | ROC-AUC, precision, recall, F1, top-k agreement |
+| Image editing | Instruction tokens or visual regions | Required edit terms or target edit region | Token-ranking agreement, edited-region overlap, expert judgement |
+| Point cloud | Points, clusters, object parts | Part segmentation or annotated relevant cluster | Point/cluster overlap, coverage, top-k part agreement |
+| KG-RAG | Entities, relations, paths | Gold evidence graph or supported reasoning path | Evidence precision/recall, ranking, path overlap |
+| ConceptSMILE | Concepts and concept-relevant regions | Domain concept annotation | Concept-region alignment, concept detection agreement |
+
+## LLM example from gSMILE
+
+The gSMILE paper compares token attribution scores with ground-truth labels identifying relevant input words. It operationalises ATT accuracy with the ROC-AUC of attribution scores: a score of 1 indicates perfect ranking of relevant tokens above irrelevant tokens, while 0.5 corresponds to random ranking.
+
+<figure markdown>
+  ![gSMILE token attribution evaluation concepts](https://arxiv.org/html/Figures/evaluate_metrics_hq.png)
+  <figcaption>
+    The gSMILE example compares token-level ground truth with generated token attributions. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS1">Figure 6 and Section 4.4.1</a>.
+  </figcaption>
+</figure>
+
+## Image functions currently implemented in XWhy
+
+XWhy currently provides image-specific spatial coverage functions through `ImageCoverageMetrics`:
+
+```python
+from xwhy.metrics import ImageCoverageMetrics
+
+coverage = ImageCoverageMetrics.calculate_coverage(
+    explanation_image=explanation_map,
+    semantic_mask=ground_truth_mask,
+    class_of_interest=1,
+)
+
+weighted_coverage = ImageCoverageMetrics.calculate_weighted_coverage(
+    explanation_image=explanation_map,
+    semantic_mask=ground_truth_mask,
+    class_of_interest=1,
+)
+
+coverage, weighted_coverage = ImageCoverageMetrics.evaluate_all(
+    explanation_image=explanation_map,
+    semantic_mask=ground_truth_mask,
+    class_of_interest=1,
+)
+```
+
+`calculate_coverage()` rewards selected explanation pixels within the target class and penalises selected pixels belonging to other labelled objects. `calculate_weighted_coverage()` additionally uses the magnitude of the explanation map.
+
+The image-classification explainer can calculate these values when a ground-truth mask is supplied or when its configured segmentation pathway produces a semantic mask:
+
+```python
+result = explainer.explain(
+    instance="image.jpg",
+    ground_truth_mask=mask,
+)
+
+print(result.coverage)
+print(result.weighted_coverage)
+```
+
+!!! important "Coverage is an image-specific ATT accuracy proxy"
+    These functions do not implement a universal ATT accuracy metric. They assume spatial arrays with matching image dimensions and a semantic mask. They cannot be directly applied to LLM tokens, point-cloud clusters, knowledge-graph evidence, or concept lists.
+
+## Current support for other modalities
+
+XWhy does not currently expose a public token-level AttAUC/F1 evaluator or a generic attribution-reference alignment class. For an LLM evaluation, the expected inputs would be an attribution score per token and a binary or graded reference relevance label aligned to the same tokenisation. That evaluator remains to be implemented in the package.
+
+Similarly, point-cloud, image-editing, GraphRAG, and concept-level ATT accuracy require modality-specific feature alignment before a metric can be computed.
+
+## Reporting checklist
+
+Report:
+
+- who or what produced the reference attribution;
+- annotation granularity and uncertainty;
+- feature-alignment and tokenisation rules;
+- whether negative attributions are included or transformed;
+- threshold or top-k selection rules;
+- class imbalance;
+- both ranking and set/coverage results where possible.
+
+!!! caution "Plausibility is not accuracy"
+    An explanation may look reasonable without aligning with a defensible reference. Conversely, disagreement with one annotation does not automatically prove an explanation is wrong when the task admits multiple valid evidence sets.
+
+## Research basis
+
+- [gSMILE](https://arxiv.org/abs/2505.21657) defines token-level ATT accuracy using annotated relevant text elements and AttAUC.
+- [ConceptSMILE](https://arxiv.org/abs/2607.09649) evaluates whether concept attributions align with clinically meaningful retinal evidence.

--- a/docs/evaluation/attribution-consistency.md
+++ b/docs/evaluation/attribution-consistency.md
@@ -1,0 +1,112 @@
+---
+title: ATT Consistency
+description: Evaluate the reproducibility of an explanation across repeated executions of the same analysis.
+---
+
+# ATT consistency
+
+**ATT consistency** asks whether the same input, model, explanation configuration, and intended operating conditions produce reproducible attributions across repeated executions.
+
+Unlike [ATT stability](attribution-stability.md), the evaluated input is not deliberately changed. Consistency isolates execution variability arising from random perturbation sampling, surrogate fitting, stochastic model generation, provider behaviour, hardware, or other uncontrolled factors.
+
+## General protocol
+
+For a fixed input \(x\), run the explanation procedure \(R\) times:
+
+```text
+a¹(x), a²(x), ..., aᴿ(x)
+```
+
+Compare the attribution vectors, rankings, selected feature sets, and any relevant output signals across runs.
+
+## Sources of inconsistency
+
+- random perturbation sampling;
+- random initialisation or optimisation in the surrogate;
+- non-deterministic black-box inference;
+- LLM sampling temperature and provider-side variability;
+- stochastic segmentation or clustering;
+- changes in retrieved evidence for RAG systems;
+- unstable feature construction or alignment;
+- different distance, kernel, or hyperparameter choices when these are intended to be fixed.
+
+## Modality-specific interpretation
+
+| Modality | Repeated object | Consistency evidence |
+|---|---|---|
+| Image classification | Same image and explanation configuration | Similar superpixel rankings and attribution magnitudes |
+| LLM / gSMILE | Same prompt, model, parameters, and provider setup | Similar token weights and generated response behaviour |
+| Image editing | Same source image, instruction, seed policy, and editor | Similar instruction attributions and edited-image effects |
+| Point cloud | Same point cloud and preprocessing | Similar point/cluster importance despite execution randomness |
+| KG-RAG | Same query, graph snapshot, retrieval configuration, and model | Similar evidence ranking and attribution paths |
+| ConceptSMILE | Same image, concept pathway, prompt, and perturbation design | Low variation in concept scores and feature importance |
+
+## Measures
+
+ConceptSMILE treats lower variance and standard deviation across repeated executions as stronger reproducibility. Depending on the modality, report:
+
+- per-feature mean, variance, and standard deviation;
+- confidence intervals for attribution values;
+- Jaccard overlap of top-k feature sets;
+- rank correlation between repeated attribution orderings;
+- frequency with which each feature enters the top-k set;
+- variance of summary metrics such as fidelity or coverage.
+
+A simple user-side analysis can use XWhy result coefficients:
+
+```python
+import numpy as np
+
+runs = [explainer.explain(instance) for _ in range(10)]
+coefficient_matrix = np.vstack([result.coefficients for result in runs])
+
+mean_attribution = coefficient_matrix.mean(axis=0)
+std_attribution = coefficient_matrix.std(axis=0)
+variance = coefficient_matrix.var(axis=0)
+```
+
+This assumes that the feature space is identical across runs. For image explanations, regenerated superpixels may differ; for point-cloud explanations, clusters may change; and for LLMs, word or token segmentation must remain aligned.
+
+## Current XWhy support
+
+XWhy exposes the attribution vector and raw evaluation data needed for repeated-run analysis, but there is currently **no dedicated public `ATTConsistency` function**.
+
+Relevant controls include:
+
+- explainer random seeds;
+- LLM temperature and provider options;
+- perturbation count;
+- surrogate type and automatic surrogate selection;
+- distance metric and locality weighting;
+- segmentation or feature-construction configuration.
+
+For LLMs, setting `temperature=0.0` and a fixed seed reduces known sampling variation, but an external provider may still be non-deterministic. Report the provider, model version, request parameters, date, and repeated outputs.
+
+## Consistency across hyperparameters
+
+The gSMILE discussion also considers consistency across model runs or hyperparameter settings. This should be reported separately from strict repeated-run consistency:
+
+- **repeatability:** same input and same configuration;
+- **configuration robustness:** same input under deliberately varied but plausible settings.
+
+Mixing these experiments into one score obscures whether variability came from randomness or an intentional design change.
+
+## Reporting checklist
+
+Report:
+
+- number of repeated runs;
+- all fixed and varying parameters;
+- random seeds and deterministic settings;
+- provider/model version and retrieval snapshot where relevant;
+- feature-alignment procedure;
+- per-feature variability and aggregate overlap;
+- uncertainty intervals rather than only one average score.
+
+!!! caution "Consistency is not stability or validity"
+    Repeatable explanations may still be inaccurate or unfaithful. Conversely, a stochastic model may produce some attribution variability even when the explanation method is behaving appropriately. Interpret consistency together with the task and model's expected randomness.
+
+## Research basis
+
+- [gSMILE](https://arxiv.org/abs/2505.21657) defines ATT consistency through repeatable token weights and outputs for repeated use of the same prompt.
+- [ConceptSMILE](https://arxiv.org/abs/2607.09649) evaluates reproducibility through repeated execution and reports variance and standard deviation as consistency indicators.

--- a/docs/evaluation/attribution-faithfulness.md
+++ b/docs/evaluation/attribution-faithfulness.md
@@ -1,0 +1,110 @@
+---
+title: ATT Faithfulness
+description: Evaluate whether attributed importance corresponds to genuine model-response changes under modality-appropriate interventions.
+---
+
+# ATT faithfulness
+
+**ATT faithfulness** asks whether attributed importance reflects the model's actual response behaviour rather than only producing a plausible-looking explanation.
+
+A faithful explanation should assign greater importance to evidence whose controlled removal, replacement, or preservation causes a correspondingly meaningful change in the black-box response.
+
+## General intervention principle
+
+For an interpretable feature \(j\):
+
+1. obtain its attribution score \(a_j\);
+2. intervene on feature \(j\) or on a feature set ranked by attribution;
+3. measure the resulting black-box response change \(\Delta_j\);
+4. test whether attribution magnitude and response effect agree.
+
+The intervention and response variable must be meaningful for the modality. Masking a superpixel, removing a token, deleting a graph relation, and suppressing a concept region are different experimental operations.
+
+## Modality-specific operationalisations
+
+| Modality | Intervention | Response effect |
+|---|---|---|
+| Image classification | Mask or preserve attributed regions | Change in class probability or prediction |
+| LLM / gSMILE | Remove, replace, or retain attributed tokens/phrases | Semantic or distributional change in the generated output |
+| Image editing | Modify attributed instruction terms or conditioning evidence | Change in edited-image semantics, structure, or target region |
+| Point cloud | Remove or alter attributed points/clusters | Change in class, detection, or segmentation response |
+| KG-RAG | Remove attributed entities, relations, paths, or retrieved passages | Change in evidence use, answer support, or semantic output |
+| ConceptSMILE | Perturb evidence relevant or irrelevant to a concept | Change in concept confidence or semantic concept response |
+
+## Two paper-specific definitions
+
+The SMILE-family papers use related but not identical operationalisations.
+
+### gSMILE
+
+The gSMILE paper defines the general goal as ensuring that important tokens genuinely drive the LLM response. Its reported quantitative evaluation treats faithfulness as an **externally validated property**, using Pearson correlation between attribution metrics and published benchmark accuracies for the evaluated models. A stronger positive correlation indicates that the attribution measurements track external model competence.
+
+### ConceptSMILE
+
+ConceptSMILE uses a direct perturbation-response interpretation. Concept-relevant perturbations should produce larger concept-confidence shifts than irrelevant perturbations. This evaluates whether the concept explanation is connected to the pathway's observed behaviour rather than only appearing clinically or semantically plausible.
+
+!!! important "Do not treat these definitions as interchangeable"
+    External benchmark correlation and direct intervention-response agreement answer different questions. A study must state which operationalisation is used and why it is appropriate for the modality and claim being tested.
+
+## Current XWhy support
+
+XWhy currently has **no standalone public `ATTFaithfulness` evaluator**. The explainers do, however, return raw perturbation and response data that can support modality-specific analysis.
+
+For an LLM result, relevant fields include:
+
+```python
+result.raw_data["perturbed_texts"]
+result.raw_data["wmd_scores"]
+result.raw_data["similarities"]
+result.raw_data["weights"]
+result.raw_data["y_target"]
+result.coefficients
+```
+
+For an image-classification result, relevant fields include:
+
+```python
+result.raw_data["x_matrix"]
+result.raw_data["predictions"]
+result.raw_data["distances"]
+result.raw_data["weights"]
+result.raw_data["y_target"]
+result.coefficients
+```
+
+These arrays expose the sampled perturbations and observed response signals, but they do not by themselves constitute a complete faithfulness test. The user must define the intervention ranking, response measure, feature alignment, baseline, and aggregation procedure.
+
+## Example study design
+
+A direct perturbation faithfulness experiment can compare cumulative response change as increasingly important features are removed:
+
+```text
+1. Rank features by |attribution|.
+2. Remove the top 1, top 2, ..., top k features.
+3. Re-query the black-box model after each intervention.
+4. Measure output change relative to the unmodified input.
+5. Compare against random-feature and low-attribution baselines.
+```
+
+For generative systems, output change should be measured semantically or distributionally rather than through exact string or pixel equality.
+
+## Reporting checklist
+
+Report:
+
+- the exact faithfulness definition;
+- whether the test is direct intervention-based or externally validated;
+- the intervention operator and realism constraints;
+- the output-distance or response-change function;
+- positive, negative, and absolute attribution handling;
+- random and low-importance baselines;
+- intervention order and cumulative-removal policy;
+- model stochasticity and repeated-query uncertainty.
+
+!!! caution "Perturbation artefacts can imitate faithfulness"
+    An intervention may create an unrealistic input that changes the model response for reasons unrelated to the attributed evidence. Use modality-appropriate perturbations, compare against controls, and report whether the modified input remains valid.
+
+## Research basis
+
+- [gSMILE](https://arxiv.org/abs/2505.21657) defines token-level faithfulness and reports an external correlation-based evaluation.
+- [ConceptSMILE](https://arxiv.org/abs/2607.09649) evaluates whether concept-relevant evidence perturbations produce the expected concept-response shifts.

--- a/docs/evaluation/attribution-fidelity.md
+++ b/docs/evaluation/attribution-fidelity.md
@@ -1,0 +1,124 @@
+---
+title: ATT Fidelity
+description: Define and measure local-surrogate attribution fidelity across XWhy modalities, including the currently implemented regression metrics.
+---
+
+# ATT fidelity
+
+**ATT fidelity** asks whether the interpretable local surrogate reproduces the black-box model's response within the perturbation neighbourhood used to generate the explanation.
+
+It evaluates the explanation mechanism, not the original model's task accuracy. A classifier can be accurate while its local explanation has poor fidelity, and a highly faithful surrogate can accurately approximate undesirable black-box behaviour.
+
+## General formulation
+
+For perturbations \(z_i\), let:
+
+- \(y_i\) be the black-box response or response shift;
+- \(\hat{y}_i\) be the local surrogate prediction;
+- \(w_i\) be the locality weight assigned to the perturbation.
+
+ATT fidelity compares \(y_i\) and \(\hat{y}_i\), with local samples receiving the weights specified by the explanation method.
+
+## What changes by modality
+
+| Modality | Black-box target \(y\) | Surrogate target \(\hat{y}\) |
+|---|---|---|
+| Image classification | Predicted-class probability after masking superpixels | Probability shift predicted from the retained-superpixel vector |
+| LLM / gSMILE | Semantic or distributional output shift after prompt perturbation | Output shift predicted from retained or altered tokens |
+| Image editing | Perceptual, embedding, structural, or semantic change in the edited image | Change predicted from instruction-token or condition perturbations |
+| Point cloud | Class, detection, or segmentation response after point/cluster perturbation | Response predicted from retained points, clusters, or parts |
+| KG-RAG | Answer or semantic-response shift after removing graph evidence | Shift predicted from retained entities, relations, paths, or retrieved items |
+| ConceptSMILE | Concept-confidence or concept-response shift after evidence perturbation | Concept-response shift predicted from the perturbation vector |
+
+The metrics may have the same names across modalities, but their raw values are only comparable when the response variables and scaling are comparable.
+
+## Metrics currently implemented in XWhy
+
+XWhy provides `RegressionMetrics.calculate()` and the immutable `RegressionMetricResult` container.
+
+```python
+from xwhy.metrics import RegressionMetrics
+
+fidelity = RegressionMetrics.calculate(
+    y_true=y_target,
+    y_pred=y_pred,
+    weights=locality_weights,
+    num_features=num_interpretable_features,
+)
+
+print(fidelity.weighted_r2)
+print(fidelity.weighted_adj_r2)
+print(fidelity.weighted_mse)
+print(fidelity.weighted_mae)
+```
+
+The function currently returns:
+
+| Field | Interpretation | Preferred direction |
+|---|---|---|
+| `weighted_r2` | Weighted coefficient of determination | Higher |
+| `weighted_adj_r2` | Weighted R-squared adjusted for feature count | Higher |
+| `weighted_mse` | Locality-weighted squared prediction error | Lower |
+| `weighted_mae` | Locality-weighted absolute prediction error | Lower |
+| `mean_loss` | Difference between mean target and mean prediction | Lower |
+| `mean_l1_loss` | Mean absolute residual | Lower |
+| `mean_l2_loss` | Mean squared residual | Lower |
+| `weighted_l1_norm` | Weighted absolute residual norm | Lower |
+| `weighted_l2_norm` | Weighted squared residual norm | Lower |
+
+## Reading fidelity from an explanation result
+
+Both currently implemented explainers attach the fidelity result to `result.metrics`.
+
+```python
+result = explainer.explain(instance)
+
+print(result.metrics)
+print(result.metrics.weighted_r2)
+print(result.metrics.weighted_mae)
+```
+
+The result also stores the arrays used for fidelity evaluation:
+
+```python
+y_target = result.raw_data["y_target"]
+y_pred = result.raw_data["y_pred"]
+weights = result.raw_data["weights"]
+```
+
+A fidelity plot can be generated from an XWhy result:
+
+```python
+result.plot(show=True)
+```
+
+## LLM example
+
+In gSMILE, prompt perturbations are represented by token-retention vectors. The black-box target is the semantic output shift caused by each perturbed prompt, and the local surrogate predicts that shift from the interpretable token vector. The paper evaluates alignment using R-squared variants and error-based metrics.
+
+<figure markdown>
+  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/Figures/fidelity.png)
+  <figcaption>
+    ATT fidelity in gSMILE compares the black-box response signal with the local surrogate signal over the same prompt perturbations. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS5">Figure 7</a>.
+  </figcaption>
+</figure>
+
+## Interpretation requirements
+
+Report fidelity together with:
+
+- the response variable and its scale;
+- the perturbation count and generation procedure;
+- the locality distance and weighting kernel;
+- the surrogate family and feature count;
+- whether model outputs were deterministic;
+- the distribution of locality weights;
+- both an accuracy-based and an error-based fidelity metric.
+
+!!! caution "High fidelity is local and conditional"
+    A high score only demonstrates that the selected surrogate approximates the sampled black-box responses under the stated neighbourhood and weighting scheme. It does not establish global equivalence, causal validity, attribution accuracy, stability, consistency, or human usefulness.
+
+## Research basis
+
+- [gSMILE](https://arxiv.org/abs/2505.21657) defines ATT fidelity for LLM token attribution using local surrogate agreement.
+- [ConceptSMILE](https://arxiv.org/abs/2607.09649) applies surrogate fidelity to concept-response behaviour and shows that fidelity can differ by concept pathway and locality weighting.

--- a/docs/evaluation/attribution-stability.md
+++ b/docs/evaluation/attribution-stability.md
@@ -1,0 +1,104 @@
+---
+title: ATT Stability
+description: Evaluate whether an explanation remains robust under small, meaning-preserving or irrelevant input changes.
+---
+
+# ATT stability
+
+**ATT stability** asks whether an explanation remains similar when the input is changed slightly without materially changing the evidence or task meaning.
+
+The input is deliberately changed. This distinguishes stability from [ATT consistency](attribution-consistency.md), where the input and intended configuration remain the same and only repeated execution varies.
+
+## Stability experiment
+
+A stability test requires paired inputs:
+
+```text
+original input x
+nearby input x' that should preserve the relevant meaning or evidence
+```
+
+Generate explanations \(a(x)\) and \(a(x')\), align their feature spaces, and quantify the difference. The perturbation used to test stability must be separate from the perturbations used internally to construct each local explanation.
+
+## What counts as a small change
+
+| Modality | Stability perturbation examples | Features compared |
+|---|---|---|
+| Image classification | Mild brightness/noise change, non-destructive crop, irrelevant border or acquisition artefact | Attribution maps, superpixels, ranked regions |
+| LLM / gSMILE | Semantically neutral insertion, minor paraphrase, punctuation or wording variation | Token/phrase rankings after semantic alignment |
+| Image editing | Equivalent rephrasing of an instruction; irrelevant instruction detail | Instruction-token attribution or affected visual regions |
+| Point cloud | Small coordinate jitter, order permutation, class-preserving rotation, limited irrelevant dropout | Points, clusters, object parts |
+| KG-RAG | Add/remove irrelevant graph evidence or equivalent retrieval context | Entities, relations, paths, retrieved items |
+| ConceptSMILE | Non-clinical artefacts or changes outside concept-relevant evidence | Concept scores, concept regions, rankings |
+
+A transformation must be justified as meaning-preserving for the task. For example, an arbitrary rotation may preserve an object class in one point-cloud task but invalidate orientation-sensitive tasks.
+
+## LLM definition in gSMILE
+
+The gSMILE paper examines whether token attributions remain similar after small prompt changes. It uses the Jaccard index to compare sets of important elements, with values closer to 1 indicating greater overlap.
+
+```python
+# User-side stability recipe; not a dedicated XWhy API function.
+def jaccard(set_a: set[int], set_b: set[int]) -> float:
+    union = set_a | set_b
+    return 1.0 if not union else len(set_a & set_b) / len(union)
+```
+
+A top-k comparison using XWhy result coefficients can be constructed as follows:
+
+```python
+import numpy as np
+
+result_a = explainer.explain(prompt_a)
+result_b = explainer.explain(prompt_b)
+
+k = 5
+top_a = set(np.argsort(np.abs(result_a.coefficients))[-k:])
+top_b = set(np.argsort(np.abs(result_b.coefficients))[-k:])
+score = jaccard(top_a, top_b)
+```
+
+!!! warning "Feature alignment is required"
+    Direct token indices are only comparable when the two prompts have compatible token or word positions. Paraphrases require semantic phrase alignment, not naive index matching. Image superpixels and point-cloud clusters may also change between inputs and require spatial matching.
+
+## Current XWhy support
+
+XWhy result objects expose:
+
+- `result.coefficients` for feature attributions;
+- `result.feature_names` for tokens or generated feature labels;
+- `result.raw_data` for perturbation and response arrays.
+
+There is currently **no dedicated public `ATTStability` evaluator**. The comparison procedure must therefore be defined by the user and should be reported as an external evaluation built from XWhy results.
+
+## Recommended measures
+
+Use one or more of the following, depending on modality:
+
+- Jaccard overlap of top-k important features;
+- rank correlation after feature alignment;
+- cosine similarity between aligned attribution vectors;
+- spatial overlap or distance between attribution maps;
+- change in concept attribution scores;
+- explanation-distribution divergence across a set of benign transformations.
+
+Do not use only a set-overlap score when attribution magnitude and direction are important.
+
+## Reporting checklist
+
+Report:
+
+- why the input change should preserve task meaning;
+- the transformation magnitude and random seed;
+- how features were aligned across inputs;
+- whether predictions or generated outputs also remained equivalent;
+- the attribution comparison measure and top-k rule;
+- results across multiple samples and transformations, not one pair only.
+
+!!! caution "Stable does not mean correct"
+    A consistently wrong or unfaithful explanation can be highly stable. Stability must be interpreted alongside ATT accuracy, fidelity, and faithfulness.
+
+## Research basis
+
+- [gSMILE](https://arxiv.org/abs/2505.21657) evaluates token-attribution stability under minor prompt changes and uses Jaccard similarity.
+- [ConceptSMILE](https://arxiv.org/abs/2607.09649) tests whether concept explanations remain robust under controlled non-clinical artefacts and irrelevant visual changes.

--- a/docs/evaluation/index.md
+++ b/docs/evaluation/index.md
@@ -1,23 +1,88 @@
 ---
-title: Evaluate XWhy Explanations
-description: Current status and planned guidance for assessing fidelity, stability, robustness, runtime, and usefulness of XWhy explanations.
+title: Evaluate Explanations Across Modalities
+description: A modality-aware framework for ATT fidelity, accuracy, stability, consistency, and faithfulness in XWhy and the SMILE research family.
 ---
 
-# Evaluate explanations
+# Evaluate explanations across modalities
 
-Implemented XWhy result objects expose evaluation metrics, and current tutorials show how to inspect `result.metrics`.
+Explanation quality is **multi-dimensional**. The SMILE research family evaluates explanations through five complementary questions:
 
-!!! warning "Metric catalogue under construction"
-    A verified catalogue defining every metric, its direction, range, assumptions, and recommended interpretation is still being prepared. Do not invent universal acceptance thresholds.
+1. **[ATT fidelity](attribution-fidelity.md):** does the local surrogate reproduce the black-box model's behaviour in the sampled neighbourhood?
+2. **[ATT accuracy](attribution-accuracy.md):** do high attribution scores align with an appropriate reference attribution?
+3. **[ATT stability](attribution-stability.md):** does the explanation remain similar after a small, semantically irrelevant change to the input?
+4. **[ATT consistency](attribution-consistency.md):** is the explanation reproducible when the same analysis is repeated under equivalent conditions?
+5. **[ATT faithfulness](attribution-faithfulness.md):** does attributed importance correspond to genuine changes in the model response when the attributed evidence is changed?
 
-The evaluation documentation will cover:
+`ATT` means **attribution**, following the terminology used in [gSMILE](https://arxiv.org/abs/2505.21657).
 
-- local surrogate fidelity;
-- stability across seeds and nearby inputs;
-- perturbation realism;
-- sensitivity to distance and surrogate choices;
-- runtime and provider cost;
-- comparison with baselines;
-- task-specific human usefulness.
+!!! important "The metric question may be shared; the metric definition is modality-specific"
+    A metric name is not a complete specification. For every evaluation, report the feature unit, perturbation, model response, reference evidence, aggregation rule, and direction of improvement. A token-level ATT accuracy score is not operationally equivalent to a superpixel-coverage score, even though both test attribution alignment.
 
-Until that catalogue is complete, report metric names, configurations, raw values, and comparison conditions transparently.
+## Why definitions change by modality
+
+Each modality exposes a different interpretable unit and a different observable model response.
+
+| Modality | Interpretable unit | Typical perturbation | Response being explained | Possible reference evidence |
+|---|---|---|---|---|
+| Image classification | Pixel, superpixel, region, or concept | Mask, replace, blur, or preserve a region | Class score or probability shift | Semantic mask, object region, expert annotation |
+| Large language model | Token, word, phrase, or prompt component | Remove, mask, replace, or paraphrase text | Semantic or distributional output shift | Human-labelled influential tokens, benchmark evidence |
+| Instruction-based image editing | Instruction token or phrase; sometimes image region | Modify the instruction or condition | Perceptual, embedding, structural, or semantic image change | Required edit concepts, edited regions, human judgement |
+| Point cloud | Point, cluster, segment, or object part | Remove, mask, jitter, rotate, or resample points | Class or detection response shift | Ground-truth object part, spatial cluster, expert annotation |
+| Knowledge graph / GraphRAG | Entity, relation, path, subgraph, or retrieved item | Remove or replace graph evidence | Answer, retrieval, or semantic-response shift | Gold evidence, supported path, answer annotation |
+| Concept-based explanation | Human-understandable concept and its evidence | Perturb concept-relevant regions or inputs | Concept confidence or semantic concept response | Domain annotation, concept mask, expert judgement |
+
+The same broad reliability question therefore requires a modality-specific operationalisation. For example, gSMILE evaluates token attributions around an LLM prompt, whereas ConceptSMILE evaluates visual or semantic concept responses under image-region perturbation. The latter paper also shows why the five dimensions should not be collapsed into one score: an explanation pathway may be spatially accurate but less faithful, stable but inconsistent, or locally well approximated while weak on another reliability dimension.
+
+## LLM example from gSMILE
+
+The following gSMILE figure illustrates how ATT accuracy, faithfulness, stability, and consistency are formulated around **token-level** explanations. Ground-truth token importance, repeated runs, and minimally changed prompts provide different comparison conditions.
+
+<figure markdown>
+  ![gSMILE framework for ATT accuracy, faithfulness, stability, and consistency](https://arxiv.org/html/Figures/evaluate_metrics_hq.png)
+  <figcaption>
+    Token-level attribution evaluation in gSMILE. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4">Explaining Large Language Models with gSMILE</a>, Figure 6.
+  </figcaption>
+</figure>
+
+ATT fidelity requires a separate comparison between the black-box response signal and the local surrogate response over the same perturbations.
+
+<figure markdown>
+  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/Figures/fidelity.png)
+  <figcaption>
+    ATT fidelity workflow in gSMILE. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS5">Explaining Large Language Models with gSMILE</a>, Figure 7.
+  </figcaption>
+</figure>
+
+## Required evaluation specification
+
+Before reporting any metric, define the following tuple:
+
+```text
+(feature unit, perturbation operator, response variable,
+ reference evidence, neighbourhood, aggregation, randomness controls)
+```
+
+For example, an LLM stability experiment might use words as features, semantically neutral phrase insertion as the perturbation, top-k token attribution as the explanation, Jaccard overlap as the aggregation, and a fixed model configuration. An image stability experiment might instead compare attribution maps after a benign acquisition artefact or non-destructive transformation.
+
+## Current XWhy implementation coverage
+
+The documentation distinguishes **implemented package functions** from evaluation procedures described in the papers.
+
+| Dimension | Current XWhy support | Notes |
+|---|---|---|
+| ATT fidelity | **Implemented** | `RegressionMetrics.calculate()` is used by the image-classification and LLM explainers. Result objects expose weighted error and R-squared metrics. |
+| ATT accuracy | **Partially implemented for images** | `ImageCoverageMetrics` measures spatial agreement with a semantic mask. This is an image-specific coverage measure, not a universal ATT accuracy function. |
+| ATT stability | **Methodology documented** | No dedicated public package evaluator is currently implemented. Explanations can be compared using returned coefficients and feature names. |
+| ATT consistency | **Methodology documented** | No dedicated public package evaluator is currently implemented. Repeated-run analysis must currently be performed by the user. |
+| ATT faithfulness | **Methodology documented** | No standalone public package evaluator is currently implemented. The required intervention and response comparison depends on the modality. |
+
+!!! warning "Do not invent universal thresholds"
+    Metric values depend on the response scale, perturbation protocol, feature granularity, neighbourhood, model stochasticity, reference annotations, and aggregation method. Report configurations and comparative baselines rather than applying one acceptance threshold across modalities.
+
+## Source papers
+
+The evaluation framework is grounded primarily in:
+
+- [Explaining Large Language Models with gSMILE](https://arxiv.org/abs/2505.21657), which defines the five ATT dimensions for token-level LLM explanations.
+- [ConceptSMILE: Auditing the Trustworthiness of Concept-Based Explainable AI](https://arxiv.org/abs/2607.09649), which reformulates the dimensions for concept-level visual and semantic explanations.
+- [XWhy and SMILE publications](../research/publications.md), which lists the broader modality-specific research family.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -81,7 +81,12 @@ plugins:
           - concepts/local-explanations.md: Scope of local explanations
           - concepts/limitations.md: Limitations and responsible interpretation
         Evaluation:
-          - evaluation/index.md: Explanation-quality evaluation status
+          - evaluation/index.md: Modality-aware explanation evaluation overview
+          - evaluation/attribution-fidelity.md: ATT fidelity and implemented surrogate metrics
+          - evaluation/attribution-accuracy.md: ATT accuracy and image coverage functions
+          - evaluation/attribution-stability.md: ATT stability under small input changes
+          - evaluation/attribution-consistency.md: ATT consistency across repeated executions
+          - evaluation/attribution-faithfulness.md: ATT faithfulness under interventions
         Research:
           - research/index.md: Research and reproducibility entry point
           - research/citation.md: How to cite XWhy
@@ -140,7 +145,13 @@ nav:
       - Connect Custom Models: how-to/custom-models.md
       - Configure LLM Providers: how-to/providers.md
       - Reproducible Explanations: how-to/reproducibility.md
-  - Evaluation: evaluation/index.md
+  - Evaluation:
+      - Overview: evaluation/index.md
+      - ATT Fidelity: evaluation/attribution-fidelity.md
+      - ATT Accuracy: evaluation/attribution-accuracy.md
+      - ATT Stability: evaluation/attribution-stability.md
+      - ATT Consistency: evaluation/attribution-consistency.md
+      - ATT Faithfulness: evaluation/attribution-faithfulness.md
   - Research:
       - Overview: research/index.md
       - Publications: research/publications.md


### PR DESCRIPTION
## Summary

This update replaces the placeholder Evaluation page with a modality-aware catalogue of the five attribution reliability dimensions used across the SMILE research family.

## New evaluation pages

- ATT Fidelity
- ATT Accuracy
- ATT Stability
- ATT Consistency
- ATT Faithfulness

## Main design decision

The five evaluation questions are shared across modalities, but their operational definitions are not. The documentation therefore requires every metric to specify its feature unit, perturbation operator, response variable, reference evidence, neighbourhood, aggregation rule, and randomness controls.

The overview compares image classification, LLMs, instruction-based image editing, point clouds, KG/GraphRAG systems, and concept-based explanations.

## Paper grounding

- uses the gSMILE evaluation framework for token-level LLM examples;
- embeds gSMILE Figures 6 and 7 from the official arXiv HTML source with attribution;
- uses ConceptSMILE to explain concept-level accuracy, fidelity, faithfulness, stability, and consistency;
- distinguishes the paper-specific gSMILE correlation-based faithfulness evaluation from ConceptSMILE's direct perturbation-response formulation.

## XWhy implementation mapping

- documents the implemented `RegressionMetrics.calculate()` fidelity suite;
- documents `ImageCoverageMetrics` as an image-specific ATT accuracy/coverage mechanism;
- shows how `result.metrics`, `result.coefficients`, `result.feature_names`, and `result.raw_data` support evaluation;
- clearly labels stability, consistency, and faithfulness as documented methodologies without dedicated public package evaluator classes;
- avoids presenting legacy examples or planned APIs as supported package functions.

## Navigation

Evaluation is now a directory and desktop hover menu containing the overview and all five metric pages. The pages are also included in `llms.txt`.