### PR TITLE
Fix broken gSMILE evaluation images

### DIFF
--- a/docs/evaluation/attribution-accuracy.md
+++ b/docs/evaluation/attribution-accuracy.md
@@ -36,7 +36,7 @@ The reference may come from human annotation, a semantic mask, domain-expert evi
 The gSMILE paper compares token attribution scores with ground-truth labels identifying relevant input words. It operationalises ATT accuracy with the ROC-AUC of attribution scores: a score of 1 indicates perfect ranking of relevant tokens above irrelevant tokens, while 0.5 corresponds to random ranking.
 
 <figure markdown>
-  ![gSMILE token attribution evaluation concepts](https://arxiv.org/html/Figures/evaluate_metrics_hq.png)
+  ![gSMILE token attribution evaluation concepts](https://arxiv.org/html/2505.21657v5/Figures/evaluate_metrics_hq.png)
   <figcaption>
     The gSMILE example compares token-level ground truth with generated token attributions. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS1">Figure 6 and Section 4.4.1</a>.
   </figcaption>

--- a/docs/evaluation/attribution-fidelity.md
+++ b/docs/evaluation/attribution-fidelity.md
@@ -97,7 +97,7 @@ result.plot(show=True)
 In gSMILE, prompt perturbations are represented by token-retention vectors. The black-box target is the semantic output shift caused by each perturbed prompt, and the local surrogate predicts that shift from the interpretable token vector. The paper evaluates alignment using R-squared variants and error-based metrics.
 
 <figure markdown>
-  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/Figures/fidelity.png)
+  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/2505.21657v5/Figures/fidelity.png)
   <figcaption>
     ATT fidelity in gSMILE compares the black-box response signal with the local surrogate signal over the same prompt perturbations. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS5">Figure 7</a>.
   </figcaption>

--- a/docs/evaluation/index.md
+++ b/docs/evaluation/index.md
@@ -38,7 +38,7 @@ The same broad reliability question therefore requires a modality-specific opera
 The following gSMILE figure illustrates how ATT accuracy, faithfulness, stability, and consistency are formulated around **token-level** explanations. Ground-truth token importance, repeated runs, and minimally changed prompts provide different comparison conditions.
 
 <figure markdown>
-  ![gSMILE framework for ATT accuracy, faithfulness, stability, and consistency](https://arxiv.org/html/Figures/evaluate_metrics_hq.png)
+  ![gSMILE framework for ATT accuracy, faithfulness, stability, and consistency](https://arxiv.org/html/2505.21657v5/Figures/evaluate_metrics_hq.png)
   <figcaption>
     Token-level attribution evaluation in gSMILE. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4">Explaining Large Language Models with gSMILE</a>, Figure 6.
   </figcaption>
@@ -47,7 +47,7 @@ The following gSMILE figure illustrates how ATT accuracy, faithfulness, stabilit
 ATT fidelity requires a separate comparison between the black-box response signal and the local surrogate response over the same perturbations.
 
 <figure markdown>
-  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/Figures/fidelity.png)
+  ![gSMILE ATT fidelity evaluation framework](https://arxiv.org/html/2505.21657v5/Figures/fidelity.png)
   <figcaption>
     ATT fidelity workflow in gSMILE. Source: Dehghani et al., <a href="https://arxiv.org/html/2505.21657#S4.SS4.SSS5">Explaining Large Language Models with gSMILE</a>, Figure 7.
   </figcaption>


### PR DESCRIPTION
## Cause

The gSMILE figures used malformed arXiv asset URLs. The paths pointed to `/html/Figures/...` and omitted the article identifier and version, so browsers received a missing resource.

## Fix

Updates all affected references to the explicit gSMILE v5 figure paths:

- `https://arxiv.org/html/2505.21657v5/Figures/evaluate_metrics_hq.png`
- `https://arxiv.org/html/2505.21657v5/Figures/fidelity.png`

## Affected pages

- Evaluation overview
- ATT Accuracy
- ATT Fidelity

No evaluation content or captions were otherwise changed.