### PR TITLE
Add How-to Guides dropdown navigation

### DIFF
--- a/docs/assets/javascripts/xwhy-nav.js
+++ b/docs/assets/javascripts/xwhy-nav.js
@@ -24,6 +24,14 @@
     ["Point-Cloud Examples", "examples/point-cloud/"]
   ];
 
+  const howToLinks = [
+    ["How-to overview", "how-to/"],
+    ["Configure logging", "how-to/logging/"],
+    ["Connect a custom model", "how-to/custom-models/"],
+    ["Configure an LLM provider", "how-to/providers/"],
+    ["Make explanations reproducible", "how-to/reproducibility/"]
+  ];
+
   const evaluationLinks = [
     ["Evaluation overview", "evaluation/"],
     ["ATT Fidelity", "evaluation/attribution-fidelity/"],
@@ -44,7 +52,7 @@
     ["Get Started", "getting-started/"],
     ["Explainers", "explainers/", explainerLinks],
     ["Tutorials & Examples", "tutorials-and-examples/", tutorialLinks],
-    ["How-to Guides", "how-to/"],
+    ["How-to Guides", "how-to/", howToLinks],
     ["Evaluation", "evaluation/", evaluationLinks],
     ["Research", "research/", researchLinks],
     ["Contributors", "contributors/"]


### PR DESCRIPTION
## Summary

Adds a hover/focus dropdown to the custom desktop **How-to Guides** menu while preserving the existing clickable overview link.

## Direct links added

- How-to overview
- Configure logging
- Connect a custom model
- Configure an LLM provider
- Make explanations reproducible

The standard Material navigation already contains these nested pages; this change brings the custom desktop top navigation into alignment with it.