### PR TITLE
Automate release notes and API reference

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: Added and improved
+      labels:
+        - enhancement
+    - title: Fixed
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install Dependencies
         run: uv sync --group dev
 
+      - name: Check Public API Reference Contract
+        run: uv run python scripts/api_reference.py --check
+
       - name: Run Nox Sessions [All Checks] (Lint, Mypy, Tests & Matrix Tests)
         run: uv run nox
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,11 @@ on:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Publish to PyPI and GitHub Releases
+    types:
+      - completed
 
 concurrency:
   group: documentation-${{ github.ref }}
@@ -28,6 +33,9 @@ permissions:
 
 jobs:
   build-and-deploy:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -56,6 +64,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: uv run python scripts/generate_contributors.py
 
+      - name: Generate Release Notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run python scripts/generate_release_notes.py
+
       - name: Build Documentation
         run: uv run properdocs build --clean --site-dir site
 
@@ -66,8 +80,12 @@ jobs:
         run: |
           test -s site/index.html
           test -s site/llms.txt
+          test -s site/reference/index.html
+          test -s site/release-notes/index.html
           grep -q "XWhy: eXplain Why" site/llms.txt
           grep -q "getting-started/installation/" site/llms.txt
+          grep -q "API Reference" site/reference/index.html
+          grep -q "Release history" site/release-notes/index.html
           ! grep -q "index.md" site/llms.txt
 
       - name: Deploy Validated Documentation

--- a/docs/explainers/image-generation/index.md
+++ b/docs/explainers/image-generation/index.md
@@ -32,4 +32,4 @@ Image-generation documentation is expected to cover:
 
 The current code contains `Pix2PixExplainer` as an early interface. It should remain described as an implementation prototype until its behaviour, accepted inputs, perturbation strategy, result type, tests, and examples are complete.
 
-[View the current Pix2Pix API interface](../../reference/xwhy/explainers/pix2pix/)
+[View the current Pix2Pix API interface](../../reference/xwhy/explainers/pix2pix.md)

--- a/docs/explainers/image-generation/pix2pix-models.md
+++ b/docs/explainers/image-generation/pix2pix-models.md
@@ -31,4 +31,4 @@ A future worked example should document:
 - checking attribution stability across generation seeds;
 - detecting unintended changes outside the target edit region.
 
-[View the current `Pix2PixExplainer` API interface](../../reference/xwhy/explainers/pix2pix/)
+[View the current `Pix2PixExplainer` API interface](../../reference/xwhy/explainers/pix2pix.md)

--- a/docs/explainers/image/index.md
+++ b/docs/explainers/image/index.md
@@ -21,7 +21,7 @@ Current documented capabilities include:
 
 [Read the complete image-classification tutorial](../../image_classification_explainer.md)
 
-[Open the image explainer API reference](../../reference/xwhy/explainers/image/)
+[Open the image explainer API reference](../../reference/xwhy/explainers/image.md)
 
 ## Scope
 

--- a/docs/explainers/llm/index.md
+++ b/docs/explainers/llm/index.md
@@ -21,7 +21,7 @@ Current documented capabilities include:
 
 [Open the complete LLM Example](../../llm_explainer.md)
 
-[Open the LLM explainer API reference](../../reference/xwhy/explainers/llm/)
+[Open the LLM explainer API reference](../../reference/xwhy/explainers/llm.md)
 
 ## Interpretation boundary
 

--- a/docs/explainers/point-cloud.md
+++ b/docs/explainers/point-cloud.md
@@ -19,4 +19,4 @@ Planned documentation will cover:
 
 Legacy point-cloud examples exist in the repository, but they should be reviewed and migrated before being treated as current package documentation.
 
-[View the current API reference](../reference/xwhy/explainers/pointcloud/)
+[View the current API reference](../reference/xwhy/explainers/pointcloud.md)

--- a/docs/explainers/tabular.md
+++ b/docs/explainers/tabular.md
@@ -19,4 +19,4 @@ Planned documentation will cover:
 - stability and fidelity evaluation;
 - bar, waterfall, and comparison visualisations.
 
-[View the current API reference](../reference/xwhy/explainers/tabular/)
+[View the current API reference](../reference/xwhy/explainers/tabular.md)

--- a/docs/explainers/text.md
+++ b/docs/explainers/text.md
@@ -21,4 +21,4 @@ Planned documentation will cover:
 
 For implemented prompt-response analysis, use the [LLM explainer](llm/index.md).
 
-[View the current API reference](../reference/xwhy/explainers/text/)
+[View the current API reference](../reference/xwhy/explainers/text.md)

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,34 +1,83 @@
-"""Generate the code reference pages and navigation."""
+"""Generate the public API index, object pages, and internal module reference."""
 
+from __future__ import annotations
+
+import sys
 from pathlib import Path
+
 import mkdocs_gen_files
 
-nav = mkdocs_gen_files.Nav()
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+sys.path.insert(0, str(PROJECT_ROOT))
 
-root = Path(__file__).parent.parent
-src = root / "src"
+from scripts.api_reference import discover_public_api, render_api_index  # noqa: E402
 
-for path in sorted(src.rglob("*.py")):
-    module_path = path.relative_to(src).with_suffix("")
-    doc_path = path.relative_to(src).with_suffix(".md")
-    full_doc_path = Path("reference", doc_path)
 
-    parts = tuple(module_path.parts)
-
+def _module_name(path: Path) -> str:
+    """Return a Python module name for a source path."""
+    relative = path.relative_to(SRC_ROOT).with_suffix("")
+    parts = list(relative.parts)
     if parts[-1] == "__init__":
-        parts = parts[:-1]
-        doc_path = doc_path.with_name("index.md")
-        full_doc_path = full_doc_path.with_name("index.md")
-    elif parts[-1] == "__main__":
+        parts.pop()
+    return ".".join(parts)
+
+
+objects = discover_public_api()
+
+with mkdocs_gen_files.open("reference/index.md", "w") as index_file:
+    index_file.write(render_api_index(objects))
+mkdocs_gen_files.set_edit_path("reference/index.md", "scripts/api_reference.py")
+
+for item in objects:
+    object_path = Path("reference", "generated", *item.public_path.split("."))
+    object_path = object_path.with_suffix(".md")
+    with mkdocs_gen_files.open(object_path, "w") as object_file:
+        object_file.write(
+            "\n".join(
+                [
+                    f"# `{item.public_path}`",
+                    "",
+                    f"::: {item.public_path}",
+                    "    options:",
+                    "      show_root_heading: false",
+                    "      show_root_full_path: true",
+                    "      members_order: source",
+                    "",
+                ]
+            )
+        )
+    mkdocs_gen_files.set_edit_path(
+        object_path, item.source_path.relative_to(PROJECT_ROOT)
+    )
+
+for source_path in sorted((SRC_ROOT / "xwhy").rglob("*.py")):
+    if source_path.name == "__main__.py":
         continue
+    module = _module_name(source_path)
+    # Keep the historical module URL layout because guides deep-link to it.
+    module_path = Path("reference", *module.split("."))
+    if source_path.name == "__init__.py":
+        module_path = module_path / "index.md"
+    else:
+        module_path = module_path.with_suffix(".md")
 
-    nav[parts] = doc_path.as_posix()
-
-    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-        ident = ".".join(parts)
-        fd.write(f"::: {ident}")
-
-    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+    with mkdocs_gen_files.open(module_path, "w") as module_file:
+        module_file.write(
+            "\n".join(
+                [
+                    f"# `{module}`",
+                    "",
+                    f"::: {module}",
+                    "    options:",
+                    "      show_root_heading: false",
+                    "      show_root_full_path: true",
+                    "      members_order: source",
+                    "",
+                ]
+            )
+        )
+    mkdocs_gen_files.set_edit_path(module_path, source_path.relative_to(PROJECT_ROOT))
 
 with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
-    nav_file.writelines(nav.build_literate_nav())
+    nav_file.write("* [API Reference](index.md)\n")

--- a/docs/getting-started/explanation-results.md
+++ b/docs/getting-started/explanation-results.md
@@ -15,7 +15,7 @@ Typical result content includes:
 - explanation-quality metrics;
 - data required by supported plots.
 
-The exact fields depend on the modality. Consult the generated [API reference](../reference/) for the authoritative Python interface.
+The exact fields depend on the modality. Consult the generated [API reference](../reference/index.md) for the authoritative Python interface.
 
 !!! warning "Interpretation boundary"
     A high-ranked feature is associated with changes in the local surrogate approximation. It is not automatically a causal factor, a globally important feature, or evidence of the model's internal reasoning process.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ description: Use XWhy and SMILE to explain image classifiers and LLM responses, 
 - [Generate your first explanation](getting-started/quick-start.md)
 - [Choose the correct explainer](getting-started/choosing-an-explainer.md)
 - [Browse all explainers and their status](explainers/index.md)
-- [Read the generated API reference](reference/)
+- [Read the generated API reference](reference/index.md)
 
 ## Capability overview
 

--- a/docs/llm_explainer.md
+++ b/docs/llm_explainer.md
@@ -251,4 +251,4 @@ When reporting an LLM explanation:
 - test whether the main attribution pattern changes across reasonable settings; and
 - avoid presenting term contributions as hidden reasoning, causal proof, or a complete safety assessment.
 
-The [LLM explainer overview](explainers/llm/index.md) summarises the capability, and the [API reference](reference/xwhy/explainers/llm/) provides the implementation interface.
+The [LLM explainer overview](explainers/llm/index.md) summarises the capability, and the [API reference](reference/xwhy/explainers/llm.md) provides the implementation interface.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,151 @@
+# Release notes
+
+This page is generated from XWhy's published
+[GitHub Releases](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases).
+Each documentation build refreshes the summary table and the detailed notes below,
+so a new release does not require a manual documentation edit.
+
+<!-- AUTO-RELEASE-NOTES:START -->
+## Release history
+
+| Release | Released | Type | Notes |
+| --- | --- | --- | --- |
+| [v0.0.3](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.3) | 28 July 2026 | Stable | [Read notes](#release-v0-0-3) |
+| [v0.0.2](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.2) | 26 July 2026 | Stable | [Read notes](#release-v0-0-2) |
+| [v0.0.1](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1) | 13 July 2026 | Stable | [Read notes](#release-v0-0-1) |
+| [v0.0.1.dev3](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev3) | 12 July 2026 | Pre-release | [Read notes](#release-v0-0-1-dev3) |
+| [v0.0.1.dev2](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev2) | 12 July 2026 | Pre-release | [Read notes](#release-v0-0-1-dev2) |
+| [v0.0.1.dev1](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev1) | 10 July 2026 | Pre-release | [Read notes](#release-v0-0-1-dev1) |
+| [v0.0.0.1-beta](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.0.1-beta) | 11 February 2023 | Pre-release | [Read notes](#release-v0-0-0-1-beta) |
+
+For work merged since the latest release, see [`v0.0.3...main`](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.3...main).
+
+The complete notes for each release follow.
+
+## v0.0.3 {#release-v0-0-3}
+
+Released 28 July 2026 · Stable release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.3) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* Restructure documentation for scalable explainability coverage by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/52
+* Add explainer dropdown navigation and simplify docs menu by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/53
+* Separate documentation deployment from full CI by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/54
+* Fix GitHub Action versions for CI and docs deployment by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/55
+* Speed up documentation navigation by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/56
+* Remove API reference from documentation menu by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/57
+* Populate SMILE research publications and citation guidance by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/58
+* Add modality-aware ATT evaluation documentation by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/59
+* Fix broken gSMILE evaluation images by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/60
+* Add How-to Guides dropdown navigation by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/61
+* Unify LLM tutorial and worked example by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/62
+* Fix spelling and phrasing in llm-explainer.md by @Sara068 in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/63
+* Add tabular explainer by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/64
+
+### New Contributors
+* @Sara068 made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/63
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.2...v0.0.3
+
+## v0.0.2 {#release-v0-0-2}
+
+Released 26 July 2026 · Stable release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.2) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* Add image classification explainer by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/50
+
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.1...v0.0.2
+
+## v0.0.1 {#release-v0-0-1}
+
+Released 13 July 2026 · Stable release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* Fast embedding and add fedelity plot by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/46
+* fix ci for pypi and docs by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/48
+
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.1.dev3...v0.0.1
+
+## v0.0.1.dev3 — Colab integration {#release-v0-0-1-dev3}
+
+Released 12 July 2026 · Pre-release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev3) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* update docs and deployment to pypi by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/44
+* Update dependencies and fail fast for providers by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/45
+
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.1.dev2...v0.0.1.dev3
+
+## v0.0.1.dev2 — Pre-release LLMExplainer {#release-v0-0-1-dev2}
+
+Released 12 July 2026 · Pre-release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev2) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* Fix embedding models and allow runtime configuration and better docs by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/43
+
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.1.dev1...v0.0.1.dev2
+
+## v0.0.1.dev1 — Publish_Testpypi {#release-v0-0-1-dev1}
+
+Released 10 July 2026 · Pre-release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.1.dev1) · [PyPI](https://pypi.org/project/xwhy/)
+
+### What's Changed
+* Create smile_tabular_test.py by @mojgan1987 in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/11
+* Update README.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/15
+* Update setup.py by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/14
+* Update smile_graph.py by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/13
+* Update smile_tabular_test.py by @mojgan1987 in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/12
+* Create SECURITY.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/16
+* Create CODE_OF_CONDUCT.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/17
+* Create CONTRIBUTING.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/18
+* Create pull_request_template.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/19
+* Create jekyll-gh-pages.yml by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/20
+* Create index.html by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/21
+* Install the CodeSee workflow. in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/22
+* Update custom.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/23
+* Update README.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/24
+* SMILE comparison by @n-akram in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/26
+* update for time series by @n-akram in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/25
+* Update datasets.py by @eltociear in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/27
+* Update smile_text.py by @Kuniko925 in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/28
+* Add files via upload by @Mamad66Ahmadi in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/29
+* Update README.md by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/31
+* Mamad66 ahmadi patch 3 by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/32
+* Mamad66 ahmadi patch 3 by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/33
+* Fix feature dimension handling in WasserstainLIME2 by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/34
+* Refactor LLM gsmile code by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/35
+* refactor: refactor SMILE image editing by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/36
+* Refactor Image classification by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/37
+* Refactor SMILE for tabular example by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/38
+* Refactor NLP and Point Cloud part by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/39
+* [codex] Fix vulnerable example dependencies by @koo-ec in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/40
+* Fix some sec bugs in deps by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/41
+* LLM Explainer in new architecture by @HamedDaneshvar in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/42
+
+### New Contributors
+* @n-akram made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/26
+* @eltociear made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/27
+* @Kuniko925 made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/28
+* @Mamad66Ahmadi made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/29
+* @HamedDaneshvar made their first contribution in https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/pull/35
+
+**Full Changelog**: https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/compare/v0.0.0.1-beta...v0.0.1.dev1
+
+## v0.0.0.1-beta — v0.0.0.1 {#release-v0-0-0-1-beta}
+
+Released 11 February 2023 · Pre-release · [GitHub release](https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/releases/tag/v0.0.0.1-beta) · [PyPI](https://pypi.org/project/xwhy/)
+
+Introducing **XWhy**, the first draft release of our Python package! This package aims to eXplain Why with <b>SMILE</b> -- Statistical Model-agnostic Interpretability with Local Explanations for deep learning/machine learning classifiers, regressors and ranker models.
+
+In this release, we've focused on implementing the core functionality and making sure it works as expected. We're excited to get feedback from the community on how we can improve and make [package name] even better.
+
+Here's what's included in this first draft:
+- Draft functions of explainability for tabular, image, text and graph-based inputs and models.
+
+We're actively developing this package and will be releasing updates with new features and bug fixes in the near future. In the meantime, please feel free to open an issue on GitHub if you find a bug or have any suggestions.
+
+Thank you for trying **XWhy**! We hope you find it useful.
+<!-- AUTO-RELEASE-NOTES:END -->

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -90,11 +90,13 @@ plugins:
         Research:
           - research/index.md: Research and reproducibility entry point
           - research/citation.md: How to cite XWhy
+        Releases:
+          - release-notes.md: Version history and detailed release notes
         Contributors:
           - contributors.md: Contributors, maintainers, and contribution routes
           - contribute/contributing.md: Contribution guide
         API Reference:
-          - reference/: Generated Python API reference
+          - reference/index.md: Generated public Python API reference
 
 extra_css:
   - assets/stylesheets/extra.css
@@ -153,6 +155,8 @@ nav:
       - Overview: research/index.md
       - Publications: research/publications.md
       - Citation: research/citation.md
+  - API Reference: reference/index.md
+  - Release Notes: release-notes.md
   - Contributors:
       - Overview: contributors.md
       - Contributing Guide: contribute/contributing.md
@@ -167,5 +171,7 @@ not_in_nav: |
   concepts/limitations.md
   examples/index.md
   examples/llm-explainer.md
-  reference/
+  reference/generated/
+  reference/xwhy/
+  reference/SUMMARY.md
   RELEASING.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ all = [
 Homepage = "https://dependable-intelligent-systems-lab.github.io/xwhy/"
 Repository = "https://github.com/Dependable-Intelligent-Systems-Lab/xwhy.git"
 Issues = "https://github.com/Dependable-Intelligent-Systems-Lab/xwhy/issues"
+"Release Notes" = "https://dependable-intelligent-systems-lab.github.io/xwhy/release-notes/"
 
 [dependency-groups]
 dev = [

--- a/scripts/api_reference.py
+++ b/scripts/api_reference.py
@@ -1,0 +1,355 @@
+"""Discover and validate the public XWhy API without importing the package."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+PACKAGE_ROOT = SRC_ROOT / "xwhy"
+
+CATEGORY_TITLES = {
+    "config": "Configuration",
+    "core": "Core abstractions and results",
+    "distance": "Distances",
+    "explainers": "Explainers",
+    "metrics": "Metrics",
+    "models": "Models",
+    "perturbation": "Perturbation",
+    "plots": "Plots",
+    "providers": "Providers",
+    "surrogate": "Surrogate models",
+    "utils": "Utilities",
+    "xwhy": "General",
+}
+
+CATEGORY_ORDER = (
+    "explainers",
+    "core",
+    "plots",
+    "distance",
+    "models",
+    "providers",
+    "perturbation",
+    "surrogate",
+    "metrics",
+    "config",
+    "utils",
+    "xwhy",
+)
+
+
+@dataclass(frozen=True)
+class PublicObject:
+    """A public object exposed by an XWhy package."""
+
+    public_path: str
+    origin: str
+    category: str
+    summary: str
+    source_path: Path
+
+
+def _module_name(path: Path) -> str:
+    """Return a Python module name for a source file."""
+    relative = path.relative_to(SRC_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _parse(path: Path) -> ast.Module:
+    """Parse a source file and include its path in syntax errors."""
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as error:
+        raise RuntimeError(
+            f"Could not parse {path.relative_to(PROJECT_ROOT)}"
+        ) from error
+
+
+def _literal_all(tree: ast.Module, path: Path) -> list[str]:
+    """Read a literal ``__all__`` declaration from a package initializer."""
+    for node in tree.body:
+        value: ast.expr | None = None
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in node.targets
+            )
+        ) or (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            value = node.value
+
+        if value is None:
+            continue
+
+        try:
+            exports = ast.literal_eval(value)
+        except (ValueError, TypeError) as error:
+            raise RuntimeError(
+                f"{path.relative_to(PROJECT_ROOT)} must declare __all__ as a "
+                "literal list or tuple."
+            ) from error
+
+        if not isinstance(exports, (list, tuple)) or not all(
+            isinstance(name, str) for name in exports
+        ):
+            raise RuntimeError(
+                f"{path.relative_to(PROJECT_ROOT)} contains an invalid __all__."
+            )
+        if len(exports) != len(set(exports)):
+            raise RuntimeError(
+                f"{path.relative_to(PROJECT_ROOT)} contains duplicate __all__ entries."
+            )
+        return list(exports)
+
+    return []
+
+
+def _resolve_import_module(package: str, node: ast.ImportFrom) -> str:
+    """Resolve an absolute module name for an ImportFrom node."""
+    if node.level == 0:
+        return node.module or ""
+
+    package_parts = package.split(".")
+    keep = len(package_parts) - node.level + 1
+    if keep < 0:
+        raise RuntimeError(f"Invalid relative import in package {package}")
+    prefix = package_parts[:keep]
+    if node.module:
+        prefix.extend(node.module.split("."))
+    return ".".join(prefix)
+
+
+def _bindings(tree: ast.Module, package: str) -> dict[str, str]:
+    """Map names bound by a package initializer to their source objects."""
+    bindings: dict[str, str] = {}
+
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = _resolve_import_module(package, node)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                bound_name = alias.asname or alias.name
+                bindings[bound_name] = f"{module}.{alias.name}".strip(".")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                bound_name = alias.asname or alias.name.split(".")[0]
+                bindings[bound_name] = alias.name
+        elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            bindings[node.name] = f"{package}.{node.name}"
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    bindings[target.id] = f"{package}.{target.id}"
+
+    return bindings
+
+
+def _source_for_origin(origin: str) -> tuple[Path, ast.AST | None]:
+    """Find the source file and definition node for an imported object."""
+    parts = origin.split(".")
+
+    for module_length in range(len(parts) - 1, 0, -1):
+        module_parts = parts[:module_length]
+        symbol_parts = parts[module_length:]
+        module_file = SRC_ROOT.joinpath(*module_parts).with_suffix(".py")
+        package_file = SRC_ROOT.joinpath(*module_parts, "__init__.py")
+        path = module_file if module_file.is_file() else package_file
+        if not path.is_file():
+            continue
+
+        tree = _parse(path)
+        symbol_name = symbol_parts[0] if symbol_parts else ""
+        for node in tree.body:
+            if (
+                isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == symbol_name
+            ):
+                return path, node
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                if any(
+                    isinstance(target, ast.Name) and target.id == symbol_name
+                    for target in targets
+                ):
+                    return path, node
+        return path, None
+
+    raise RuntimeError(f"Could not locate source for public API object {origin}")
+
+
+def _summary(node: ast.AST | None, public_path: str) -> str:
+    """Return a one-sentence summary suitable for the API index table."""
+    if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        docstring = ast.get_docstring(node, clean=True)
+        if docstring:
+            paragraph = docstring.split("\n\n", 1)[0]
+            compact = " ".join(paragraph.split())
+            sentence = re.split(r"(?<=[.!?])\s+", compact, maxsplit=1)[0]
+            return sentence.replace("|", "\\|")
+
+    name = public_path.rsplit(".", 1)[-1]
+    return f"Public XWhy API object `{name}`."
+
+
+def _category(origin: str) -> str:
+    """Group an object by its top-level XWhy source package."""
+    parts = origin.split(".")
+    return parts[1] if len(parts) > 2 else "xwhy"
+
+
+def _is_exported_subpackage(origin: str) -> bool:
+    """Return whether an export is a package represented by its own objects."""
+    path = SRC_ROOT.joinpath(*origin.split("."), "__init__.py")
+    return path.is_file() and bool(_literal_all(_parse(path), path))
+
+
+def discover_public_api() -> list[PublicObject]:
+    """Discover the public API from root and first-level package ``__all__`` lists."""
+    root_init = PACKAGE_ROOT / "__init__.py"
+    package_inits = [root_init, *sorted(PACKAGE_ROOT.glob("*/__init__.py"))]
+    objects: list[PublicObject] = []
+    seen_origins: set[str] = set()
+
+    for init_path in package_inits:
+        package = _module_name(init_path)
+        tree = _parse(init_path)
+        exports = _literal_all(tree, init_path)
+        bindings = _bindings(tree, package)
+
+        for name in exports:
+            origin = bindings.get(name)
+            if origin is None:
+                raise RuntimeError(
+                    f"{init_path.relative_to(PROJECT_ROOT)} exports {name!r}, "
+                    "but that name is not defined or imported."
+                )
+            if origin in seen_origins or _is_exported_subpackage(origin):
+                continue
+
+            source_path, node = _source_for_origin(origin)
+            public_path = f"{package}.{name}"
+            objects.append(
+                PublicObject(
+                    public_path=public_path,
+                    origin=origin,
+                    category=_category(origin),
+                    summary=_summary(node, public_path),
+                    source_path=source_path,
+                )
+            )
+            seen_origins.add(origin)
+
+    order = {name: index for index, name in enumerate(CATEGORY_ORDER)}
+    return sorted(
+        objects,
+        key=lambda item: (
+            order.get(item.category, len(order)),
+            item.category,
+            item.public_path.casefold(),
+        ),
+    )
+
+
+def render_api_index(objects: list[PublicObject]) -> str:
+    """Render a SHAP-style summary page grouped by API area."""
+    lines = [
+        "# API Reference",
+        "",
+        (
+            "This page is generated from the public objects declared in "
+            "`src/xwhy/**/__init__.py`. Adding or removing an object from a "
+            "package's `__all__` updates this index during the next documentation "
+            "build."
+        ),
+        "",
+        (
+            "Select an object for its full signature, parameters, return values, "
+            "and documented members."
+        ),
+    ]
+
+    categories: dict[str, list[PublicObject]] = {}
+    for item in objects:
+        categories.setdefault(item.category, []).append(item)
+
+    order = {name: index for index, name in enumerate(CATEGORY_ORDER)}
+    for category in sorted(
+        categories,
+        key=lambda name: (order.get(name, len(order)), name),
+    ):
+        title = CATEGORY_TITLES.get(category, category.replace("_", " ").title())
+        lines.extend(
+            [
+                "",
+                f"## {title}",
+                "",
+                "| Object | Description |",
+                "| --- | --- |",
+            ]
+        )
+        for item in categories[category]:
+            target = "generated/" + "/".join(item.public_path.split(".")) + ".md"
+            lines.append(f"| [`{item.public_path}`]({target}) | {item.summary} |")
+
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            (
+                "Module-level documentation is also generated under "
+                "`reference/xwhy/` for maintainers and existing deep links, but "
+                "it is intentionally "
+                "excluded from the public API index."
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate public exports and print the discovered API inventory.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Validate and report the public API inventory."""
+    args = _parse_args()
+    if not args.check:
+        raise SystemExit("Use --check to validate the public API reference contract.")
+
+    objects = discover_public_api()
+    counts: dict[str, int] = {}
+    for item in objects:
+        counts[item.category] = counts.get(item.category, 0) + 1
+
+    print(f"Validated {len(objects)} public API objects from {PACKAGE_ROOT}")
+    for category, count in sorted(counts.items()):
+        title = CATEGORY_TITLES.get(category, category.title())
+        print(f"- {title}: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,226 @@
+"""Generate the XWhy release-notes page from published GitHub Releases."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_NOTES_PAGE = PROJECT_ROOT / "docs" / "release-notes.md"
+
+RELEASES_START = "<!-- AUTO-RELEASE-NOTES:START -->"
+RELEASES_END = "<!-- AUTO-RELEASE-NOTES:END -->"
+
+
+def _replace_block(text: str, replacement: str) -> str:
+    """Replace the generated block while preserving the page introduction."""
+    if text.count(RELEASES_START) != 1 or text.count(RELEASES_END) != 1:
+        raise RuntimeError(
+            f"Expected exactly one marker pair: {RELEASES_START} / {RELEASES_END}"
+        )
+
+    prefix, remainder = text.split(RELEASES_START, 1)
+    _, suffix = remainder.split(RELEASES_END, 1)
+    return f"{prefix}{RELEASES_START}\n{replacement.rstrip()}\n{RELEASES_END}{suffix}"
+
+
+def _request_json(url: str, token: str | None) -> object:
+    """Request JSON from GitHub with an optional workflow token."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "xwhy-documentation-build",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def _fetch_releases(repository: str, token: str | None) -> list[dict[str, Any]]:
+    """Fetch every published GitHub Release, newest first."""
+    releases: list[dict[str, Any]] = []
+    page = 1
+
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repository}/releases"
+            f"?per_page=100&page={page}"
+        )
+        payload = _request_json(url, token)
+        if not isinstance(payload, list):
+            raise RuntimeError("GitHub Releases API returned an unexpected response.")
+
+        for item in payload:
+            if not isinstance(item, dict) or item.get("draft"):
+                continue
+            if not item.get("tag_name") or not item.get("html_url"):
+                continue
+            releases.append(item)
+
+        if len(payload) < 100:
+            break
+        page += 1
+
+    releases.sort(
+        key=lambda release: str(
+            release.get("published_at") or release.get("created_at") or ""
+        ),
+        reverse=True,
+    )
+    return releases
+
+
+def _release_date(release: dict[str, Any]) -> str:
+    """Format a GitHub timestamp as an unambiguous human-readable date."""
+    value = str(release.get("published_at") or release.get("created_at") or "")
+    try:
+        date = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return "Unknown"
+    return f"{date.day} {date.strftime('%B %Y')}"
+
+
+def _release_anchor(tag: str) -> str:
+    """Return a stable HTML anchor for a release tag."""
+    slug = re.sub(r"[^a-z0-9]+", "-", tag.casefold()).strip("-")
+    return f"release-{slug}"
+
+
+def _table_text(value: str) -> str:
+    """Escape dynamic text for a Markdown table cell."""
+    return html.escape(value, quote=False).replace("|", "\\|")
+
+
+def _demote_headings(body: str) -> str:
+    """Keep release-body headings below each version heading."""
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
+
+    # Some early releases contain the same GitHub-generated block twice.
+    # Remove the second copy only when both blocks are line-for-line identical.
+    starts = [
+        match.start()
+        for match in re.finditer(r"^## What's Changed\s*$", body, re.MULTILINE)
+    ]
+    if len(starts) == 2:
+        first = body[starts[0] : starts[1]].strip().splitlines()
+        second = body[starts[1] :].strip().splitlines()
+        if first == second:
+            body = body[: starts[1]].rstrip()
+
+    def replace_heading(match: re.Match[str]) -> str:
+        level = min(6, max(3, len(match.group(1)) + 1))
+        return f"{'#' * level}{match.group(2)}"
+
+    return re.sub(r"^(#{1,6})(\s+)", replace_heading, body, flags=re.MULTILINE)
+
+
+def _render_releases(releases: list[dict[str, Any]], repository: str) -> str:
+    """Render the release summary table and full release notes."""
+    if not releases:
+        return (
+            "No published releases are available yet. "
+            f"[View the repository]"
+            f"(https://github.com/{repository}/releases)."
+        )
+
+    rows = [
+        "## Release history",
+        "",
+        "| Release | Released | Type | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    for release in releases:
+        tag = str(release["tag_name"])
+        release_url = str(release["html_url"])
+        release_type = "Pre-release" if release.get("prerelease") else "Stable"
+        rows.append(
+            f"| [{_table_text(tag)}]({release_url}) "
+            f"| {_release_date(release)} | {release_type} "
+            f"| [Read notes](#{_release_anchor(tag)}) |"
+        )
+
+    latest = releases[0]
+    latest_tag = str(latest["tag_name"])
+    rows.extend(
+        [
+            "",
+            (
+                "For work merged since the latest release, see "
+                f"[`{latest_tag}...main`]"
+                f"(https://github.com/{repository}/compare/{latest_tag}...main)."
+            ),
+            "",
+            "The complete notes for each release follow.",
+        ]
+    )
+
+    for release in releases:
+        tag = str(release["tag_name"])
+        name = str(release.get("name") or tag).strip()
+        release_url = str(release["html_url"])
+        body = str(release.get("body") or "").strip()
+        release_type = "Pre-release" if release.get("prerelease") else "Stable release"
+
+        heading = tag if name == tag else f"{tag} — {name}"
+        rows.extend(
+            [
+                "",
+                f"## {_table_text(heading)} {{#{_release_anchor(tag)}}}",
+                "",
+                (
+                    f"Released {_release_date(release)} · {release_type} · "
+                    f"[GitHub release]({release_url}) · "
+                    f"[PyPI](https://pypi.org/project/xwhy/)"
+                ),
+                "",
+                _demote_headings(body)
+                if body
+                else "No release description was provided.",
+            ]
+        )
+
+    return "\n".join(rows)
+
+
+def main() -> int:
+    """Refresh the generated release-notes block in place."""
+    repository = os.getenv(
+        "GITHUB_REPOSITORY", "Dependable-Intelligent-Systems-Lab/xwhy"
+    )
+    token = os.getenv("GITHUB_TOKEN")
+    page = RELEASE_NOTES_PAGE.read_text(encoding="utf-8")
+
+    try:
+        release_section = _render_releases(
+            _fetch_releases(repository, token), repository
+        )
+    except (OSError, ValueError, RuntimeError, urllib.error.URLError) as error:
+        print(
+            f"Warning: could not refresh GitHub releases: {error}. "
+            "Keeping the existing release-notes block.",
+            file=sys.stderr,
+        )
+        release_section = (
+            page.split(RELEASES_START, 1)[1].split(RELEASES_END, 1)[0].strip()
+        )
+
+    RELEASE_NOTES_PAGE.write_text(
+        _replace_block(page, release_section), encoding="utf-8"
+    )
+    print(f"Updated {RELEASE_NOTES_PAGE.relative_to(PROJECT_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- generate a newest-first release history table and detailed notes from published GitHub Releases
- rebuild documentation after successful package publication and retain the scheduled refresh fallback
- categorize future generated release notes from pull-request labels
- discover and validate the public Python API from package `__all__` declarations without importing heavy ML dependencies
- generate a grouped API landing page, one detail page per public object, and module-level reference pages
- preserve existing API deep links and repair documentation links to generated pages

## Why

XWhy already creates GitHub Releases, but the documentation did not surface them. The existing API generator scanned modules but did not create `reference/index.md`, leaving the homepage API link at a 404 and requiring manual organization. These changes make GitHub Releases and `src/xwhy` the respective sources of truth.

## Impact

New releases and public API changes will appear in the documentation automatically. CI now rejects duplicate, missing, or invalid `__all__` exports. No theme or styling changes are included.

## Validation

- `python scripts/api_reference.py --check` — 88 public objects across 11 API areas
- Ruff check and format verification for documentation generators
- YAML configuration parsing
- release generation against the live GitHub Releases API
- cached release-note fallback on API failure
- complete ProperDocs build — 88 public object pages and 83 module pages
- clean patch application against a fresh checkout

The full documentation build passes. It still reports two pre-existing tutorial-anchor warnings unrelated to this change.